### PR TITLE
Allocate space for "Other Settings" button proportionally to the translation lengt

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  1 14:59:57 CEST 2015 - locilka@suse.com
+
+- Allocate space for "Other Settings" button proportionally to its
+  translation length (bnc#946955)
+- 3.1.24
+
+-------------------------------------------------------------------
 Tue Aug 18 14:18:52 UTC 2015 - sndirsch@suse.com
 
 - Use xkb converted console keymaps (better systemd support) where

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.23
+Version:        3.1.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/src/include/timezone/dialogs.rb
+++ b/timezone/src/include/timezone/dialogs.rb
@@ -640,8 +640,8 @@ module Yast
         # bsc#946955 Translation doesn't fit in some languages
         # Reserved space needs to be allocated proportionally to the text length
         other_settings_hweight = other_settings_label.size
-        free_space_hweight = 12
-        entries_hweight = 24
+        free_space_hweight = 10
+        entries_hweight = 25
 
         timezoneterm = VBox(
           TimezoneSelector(Id(:timezonemap), Opt(:notify), worldmap, zones),

--- a/timezone/src/include/timezone/dialogs.rb
+++ b/timezone/src/include/timezone/dialogs.rb
@@ -531,15 +531,14 @@ module Yast
 
       Timezone.PushVal
 
-
-      settime = Empty()
+      # TRANSLATORS: Button label
+      other_settings_label = _("Other &Settings...")
 
       # "On a mainframe it is impossible for the user to change the hardware clock.
-      # So you can only specify the timezone." (ihno)
-      if !Arch.s390 && !Mode.config
-        # button text
-        settime = PushButton(Id(:settime), _("Other &Settings..."))
-      end
+      # So you can only specify the timezone." (Ihno)
+      settime = ((!Arch.s390 && !Mode.config) ?
+        PushButton(Id(:settime), other_settings_label) : Empty()
+      )
 
       textmode = Language.GetTextMode
 
@@ -637,12 +636,19 @@ module Yast
       if UI.HasSpecialWidget(:TimezoneSelector) == true
         timezone_selector = true
         worldmap = Ops.add(Directory.themedir, "/current/worldmap/worldmap.jpg")
+
+        # bsc#946955 Translation doesn't fit in some languages
+        # Reserved space needs to be allocated proportionally to the text length
+        other_settings_hweight = other_settings_label.size
+        free_space_hweight = 12
+        entries_hweight = 24
+
         timezoneterm = VBox(
           TimezoneSelector(Id(:timezonemap), Opt(:notify), worldmap, zones),
           HBox(
-            HWeight(1, HStretch()),
+            HWeight(free_space_hweight, HStretch()),
             HWeight(
-              2,
+              entries_hweight,
               ComboBox(
                 Id(:region),
                 Opt(:notify),
@@ -653,25 +659,25 @@ module Yast
             ),
             HSpacing(),
             HWeight(
-              2,
+              entries_hweight,
               ComboBox(Id(:timezone), Opt(:notify), _("Time &Zone"))
             ),
             HSpacing(),
-            HWeight(1, HStretch())
+            HWeight(other_settings_hweight, HStretch())
           ),
           HBox(
-            HWeight(1, HStretch()),
-            HWeight(2, Left(
+            HWeight(free_space_hweight, HStretch()),
+            HWeight(entries_hweight, Left(
               utc_only ? Label(" ") : hwclock_term
             )),
             HSpacing(),
-            HWeight(2, HBox(
+            HWeight(entries_hweight, HBox(
               Label(_("Date and Time:")),
               Label(Id(:date), date),
               HStretch()
             )),
             HSpacing(),
-            HWeight(1, Right(settime))
+            HWeight(other_settings_hweight, Right(settime))
           )
         )
       else


### PR DESCRIPTION
- bsc#946955
- New screenshots are at https://trello.com/c/OrH3F8uW/348-2-sle12-sp1-p1-946955-yast-date-and-time-not-enough-space-for-button