### PR TITLE
Corrected Linux console keyboard mapping for French(Canada)

### DIFF
--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -118,7 +118,7 @@ return ($[
 	// keyboard layout
 	_("French (Canada)"),
 	$[
-	    "pc104"	: $[ "ncurses": "ca-fr-legacy.map.gz"],
+	    "pc104"	: $[ "ncurses": "ca.map.gz"],
 	    "macintosh" : $[ "ncurses": "mac-us.map.gz"],
 	    "type4"	: $[ "ncurses": "sunkeymap.map.gz" ],
 	    "type5"	: $[ "ncurses": "sunt5-fr-latin1.map.gz" ],

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -534,7 +534,7 @@ return ($[
 	_("Ukrainian"),
 	$[
 	    "pc104"	: $[
-		    "ncurses"	: "ua.map.gz",
+		    "ncurses"	: "ua-utf.map.gz",
 	    ],
 	    "macintosh" : $[
 		    "ncurses"	: "mac-us.map.gz"


### PR DESCRIPTION
Linux console keyboard mapping needs to  "ca" instead of
"ca-fr-legacy" (bnc#960307).