### PR TITLE
Use the new official short name for the Czech Republic: Czechia

### DIFF
--- a/timezone/src/data/timezone_raw.ycp
+++ b/timezone/src/data/timezone_raw.ycp
@@ -65,7 +65,7 @@ $[
 	"Europe/Paris" : _("France"),
 	// time zone
 	"Europe/Podgorica"	: _("Montenegro"),
-	"Europe/Prague" : _("Czech Republic"),
+	"Europe/Prague" : _("Czechia"),
 	"Europe/Riga" : _("Latvia"),
 	"Europe/Rome" : _("Italy"),
 	// time zone

--- a/timezone/testsuite/tests/MakeProposal.out
+++ b/timezone/testsuite/tests/MakeProposal.out
@@ -1,8 +1,8 @@
 Read	.etc.adjtime ["0", "0", "UTC"]
 Read	.probe.is_vmware false
-Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Berlin":"Germany", "Europe/Prague":"Czech Republic"], "name":"Europe"]]
+Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Berlin":"Germany", "Europe/Prague":"Czechia"], "name":"Europe"]]
 Execute	.target.bash_output "/usr/sbin/zic -l Europe/Prague" $[]
 Execute	.target.bash_output "/bin/systemctl try-restart systemd-timedated.service" $[]
 Execute	.target.bash_output "/sbin/hwclock --hctosys -u" $[]
 Execute	.target.bash_output "/bin/date \"+%c\"" $[]
-Return	["Europe / Czech Republic - Hardware Clock Set To UTC "]
+Return	["Europe / Czechia - Hardware Clock Set To UTC "]

--- a/timezone/testsuite/tests/MakeProposal.rb
+++ b/timezone/testsuite/tests/MakeProposal.rb
@@ -35,7 +35,7 @@ module Yast
               "name"    => "Europe",
               "entries" => {
                 "Europe/Berlin" => "Germany",
-                "Europe/Prague" => "Czech Republic"
+                "Europe/Prague" => "Czechia"
               }
             }
           ]

--- a/timezone/testsuite/tests/ReadExport.out
+++ b/timezone/testsuite/tests/ReadExport.out
@@ -1,6 +1,6 @@
 Read	.etc.adjtime ["0", "0", "LOCAL"]
-Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Prague":"Czech Republic"], "name":"Europe"]]
+Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Prague":"Czechia"], "name":"Europe"]]
 Return	nil
 Return	$["hwclock":"localtime", "timezone":"Europe/Prague"]
-Return	<ul><li>Current Time Zone: Europe / Czech Republic</li><li>Hardware Clock Set To Local Time</li></ul>
+Return	<ul><li>Current Time Zone: Europe / Czechia</li><li>Hardware Clock Set To Local Time</li></ul>
 Return	false

--- a/timezone/testsuite/tests/ReadExport.rb
+++ b/timezone/testsuite/tests/ReadExport.rb
@@ -34,7 +34,7 @@ module Yast
         [
           {
             "name"    => "Europe",
-            "entries" => { "Europe/Prague" => "Czech Republic" }
+            "entries" => { "Europe/Prague" => "Czechia" }
           }
         ]
       )

--- a/timezone/testsuite/tests/Selection.out
+++ b/timezone/testsuite/tests/Selection.out
@@ -1,7 +1,7 @@
 Read	.etc.adjtime ["0", "0", "UTC"]
-Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Berlin":"Germany", "Europe/Prague":"Czech Republic"], "name":"Europe"], $["entries":$["US/Mountain":"Mountain"], "name":"USA"]]
+Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Berlin":"Germany", "Europe/Prague":"Czechia"], "name":"Europe"], $["entries":$["US/Mountain":"Mountain"], "name":"USA"]]
 Return	[`item (`id ("US/Mountain"), "Mountain", false)]
 Return	0
-Return	[`item (`id ("Europe/Prague"), "Czech Republic", false), `item (`id ("Europe/Berlin"), "Germany", false)]
+Return	[`item (`id ("Europe/Prague"), "Czechia", false), `item (`id ("Europe/Berlin"), "Germany", false)]
 Return	2
 Return	[]

--- a/timezone/testsuite/tests/Selection.rb
+++ b/timezone/testsuite/tests/Selection.rb
@@ -30,7 +30,7 @@ module Yast
               "name"    => "Europe",
               "entries" => {
                 "Europe/Berlin" => "Germany",
-                "Europe/Prague" => "Czech Republic"
+                "Europe/Prague" => "Czechia"
               }
             },
             { "name" => "USA", "entries" => { "US/Mountain" => "Mountain" } }


### PR DESCRIPTION
The short name is now officially entered in the UNGEGN database
as of 2016-07-05: http://unstats.un.org/unsd/geoinfo/geonames/