### PR TITLE
Added check for supported languages and correcting unsupported ones

### DIFF
--- a/language/Makefile.am
+++ b/language/Makefile.am
@@ -1,4 +1,4 @@
 #
 # Makefile.am for country/language
-SUBDIRS = src testsuite
+SUBDIRS = src testsuite test
 

--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -403,17 +403,16 @@ module Yast
       # TRANSLATORS: Error message. Strings marked %{...} will be replaced
       # with variable content - do not translate them, please.
       Report.Error(
-        _("Language '%{language}' was not found within the list of supported languages
-available at %{directory}.
-
-Fallback language %{fallback} will be used." % {
+        _("Language '%{language}' was not found within the list of supported languages\n" +
+          "available at %{directory}.\n\nFallback language %{fallback} will be used."
+        ) % {
           :language => language,
           :directory => @languages_directory,
           :fallback => DEFAULT_FALLBACK_LANGUAGE
-        })
+        }
       )
 
-      language.replace(DEFAULT_FALLBACK_LANGUAGE)
+      return DEFAULT_FALLBACK_LANGUAGE
     end
 
     # Changes the install.inf in inst-sys according to newly selected language
@@ -462,7 +461,7 @@ Fallback language %{fallback} will be used." % {
       )
 
       if @language != lang
-        correct_language(lang)
+        lang = correct_language(lang)
 
         if Stage.initial && !Mode.test && !Mode.live_installation
           integrate_inst_sys_extension(@language)
@@ -474,7 +473,7 @@ Fallback language %{fallback} will be used." % {
         # In config mode, use language name translated into the current language
         # othewrwise use the language name translated into that selected language
         # because the whole UI will get translated later too
-        @name = Mode.config ? language_def[4] : language_def[0] || lang
+        @name = (Mode.config ? language_def[4] : language_def[0]) || lang
         @language = lang
         Encoding.SetEncLang(@language)
       end

--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -31,6 +31,10 @@ require "yast"
 
 module Yast
   class LanguageClass < Module
+    DEFAULT_FALLBACK_LANGUAGE = "en_US".freeze
+
+    include Yast::Logger
+
     def main
       Yast.import "Pkg"
       Yast.import "UI"
@@ -49,15 +53,19 @@ module Yast
       Yast.import "PackageSystem"
       Yast.import "Popup"
       Yast.import "ProductFeatures"
+      Yast.import "Report"
       Yast.import "SlideShow"
       Yast.import "Stage"
 
+      # directory where all the language definitions are stored
+      # it's a constant, but depends on a dynamic content (Directory)
+      @languages_directory = "#{Directory.datadir}/languages"
 
       # currently selected language
-      @language = "en_US"
+      @language = DEFAULT_FALLBACK_LANGUAGE
 
       # original language
-      @language_on_entry = "en_US"
+      @language_on_entry = DEFAULT_FALLBACK_LANGUAGE
 
       # language preselected in /etc/install.inf
       @preselected = "en_US"
@@ -68,12 +76,11 @@ module Yast
       @linuxrc_language_set = false
 
       # Default language to be restored with MakeProposal.
-      @default_language = "en_US"
+      @default_language = DEFAULT_FALLBACK_LANGUAGE
 
 
       # Default settings for ROOT_USES_LANG in /etc/sysconfig/language
       @rootlang = "ctype"
-
 
       # Default settings for INSTALLED_LANGUAGES in /etc/sysconfig/language
       @languages = ""
@@ -108,10 +115,8 @@ module Yast
       # mapping of language to its default (proposed) kbd layout
       @lang2keyboard = {}
 
-      # directory with languages descriptions
-      @languages_directory = nil
-
       # languages that cannot be correctly shown in text mode
+      # if the system (Linuxrc) does not start with them from the beginning
       @cjk_languages = [
         "ja",
         "ko",
@@ -163,9 +168,6 @@ module Yast
 
     # Read language DB: translatable strings will be translated to current language
     def read_languages_map
-      if @languages_directory == nil
-        @languages_directory = Ops.add(Directory.datadir, "/languages")
-      end
       Builtins.foreach(
         Convert.convert(
           SCR.Read(path(".target.dir"), @languages_directory, []),
@@ -204,7 +206,7 @@ module Yast
           Ops.set(
             @lang2keyboard,
             code,
-            Ops.get_string(language_map, "keyboard", "en_US")
+            Ops.get_string(language_map, "keyboard", DEFAULT_FALLBACK_LANGUAGE)
           )
         end
       end
@@ -219,9 +221,6 @@ module Yast
     def ReadLanguageMap(lang)
       ret = {}
 
-      if @languages_directory == nil
-        @languages_directory = Ops.add(Directory.datadir, "/languages")
-      end
       file = Builtins.sformat("language_%1.ycp", lang)
       if FileUtils.Exists(Ops.add(Ops.add(@languages_directory, "/"), file))
         ret = Convert.to_map(
@@ -363,70 +362,129 @@ module Yast
       filename
     end
 
+    # Downloads inst-sys extension for a given language
+    # including giving a UI feedback to the user
+    #
+    # @param [String] language, e.g. 'de_DE'
+    def integrate_inst_sys_extension(language)
+      log.info "integrating translation extension..."
+
+      # busy message
+      Popup.ShowFeedback(
+        "",
+        _("Downloading installation system language extension...")
+      )
+
+      InstExtensionImage.DownloadAndIntegrateExtension(
+        GetLanguageExtensionFilename(language)
+      )
+
+      Popup.ClearFeedback
+      log.info "integrating translation extension... done"
+    end
+
+    # Returns whether the given language string is supported by this library.
+    #
+    # @param [String] language
+    # @see @languages_directory
+    def valid_language?(language)
+      GetLanguagesMap(false).key?(language)
+    end
+
+    # Checks whether given language is supported by the installer
+    # and changes it to the default language en_US if it isn't.
+    #
+    # @param [String] reference to the new language
+    # @return [String] new (corrected) language
+    def correct_language(language)
+      # No correction needed, this is already a correct language definition
+      return language if valid_language?(language)
+
+      # TRANSLATORS: Error message. Strings marked %{...} will be replaced
+      # with variable content - do not translate them, please.
+      Report.Error(
+        _("Language '%{language}' was not found within the list of supported languages
+available at %{directory}.
+
+Fallback language %{fallback} will be used." % {
+          :language => language,
+          :directory => @languages_directory,
+          :fallback => DEFAULT_FALLBACK_LANGUAGE
+        })
+      )
+
+      language.replace(DEFAULT_FALLBACK_LANGUAGE)
+    end
+
+    # Changes the install.inf in inst-sys according to newly selected language
+    #
+    # FIXME: code just moved, refactoring needed
+    def adapt_install_inf
+      yinf = {}
+      yinf_ref = arg_ref(yinf)
+      AsciiFile.SetDelimiter(yinf_ref, " ")
+      yinf = yinf_ref.value
+      yinf_ref = arg_ref(yinf)
+      AsciiFile.ReadFile(yinf_ref, "/etc/yast.inf")
+      yinf = yinf_ref.value
+      lines = AsciiFile.FindLineField(yinf, 0, "Language:")
+
+      if Ops.greater_than(Builtins.size(lines), 0)
+        yinf_ref = arg_ref(yinf)
+        AsciiFile.ChangeLineField(
+          yinf_ref,
+          Ops.get_integer(lines, 0, -1),
+          1,
+          @language
+        )
+        yinf = yinf_ref.value
+      else
+        yinf_ref = arg_ref(yinf)
+        AsciiFile.AppendLine(yinf_ref, ["Language:", @language])
+        yinf = yinf_ref.value
+      end
+
+      yinf_ref = arg_ref(yinf)
+      AsciiFile.RewriteFile(yinf_ref, "/etc/yast.inf")
+      yinf = yinf_ref.value
+    end
 
     # Set module to selected language.
+    #
     # @param [String] lang language string ISO code of language
     def Set(lang)
+      lang = deep_copy(lang)
+
       Builtins.y2milestone(
         "original language: %1; setting to lang:%2",
         @language,
         lang
       )
 
-      if @language != lang # Do it only if different
+      if @language != lang
+        correct_language(lang)
+
         if Stage.initial && !Mode.test && !Mode.live_installation
-          Builtins.y2milestone("integrating translation extension...")
-          # busy message
-          Popup.ShowFeedback(
-            "",
-            _("Downloading installation system language extension...")
-          )
-          InstExtensionImage.DownloadAndIntegrateExtension(
-            GetLanguageExtensionFilename(lang)
-          )
-          Popup.ClearFeedback
-          Builtins.y2milestone("integrating translation extension... done")
+          integrate_inst_sys_extension(@language)
         end
-        read_languages_map if Builtins.size(@languages_map) == 0
 
         GetLocales() if Builtins.size(@locales) == 0
 
-        @name = Ops.get_string(@languages_map, [lang, 0], lang)
-        @name = Ops.get_string(@languages_map, [lang, 4], lang) if Mode.config
+        language_def = GetLanguagesMap(false).fetch(lang, [])
+        # In config mode, use language name translated into the current language
+        # othewrwise use the language name translated into that selected language
+        # because the whole UI will get translated later too
+        @name = Mode.config ? language_def[4] : language_def[0] || lang
         @language = lang
         Encoding.SetEncLang(@language)
       end
 
       if Stage.initial && !Mode.test
-        yinf = {}
-        yinf_ref = arg_ref(yinf)
-        AsciiFile.SetDelimiter(yinf_ref, " ")
-        yinf = yinf_ref.value
-        yinf_ref = arg_ref(yinf)
-        AsciiFile.ReadFile(yinf_ref, "/etc/yast.inf")
-        yinf = yinf_ref.value
-        lines = AsciiFile.FindLineField(yinf, 0, "Language:")
-        if Ops.greater_than(Builtins.size(lines), 0)
-          yinf_ref = arg_ref(yinf)
-          AsciiFile.ChangeLineField(
-            yinf_ref,
-            Ops.get_integer(lines, 0, -1),
-            1,
-            @language
-          )
-          yinf = yinf_ref.value
-        else
-          yinf_ref = arg_ref(yinf)
-          AsciiFile.AppendLine(yinf_ref, ["Language:", @language])
-          yinf = yinf_ref.value
-        end
-        yinf_ref = arg_ref(yinf)
-        AsciiFile.RewriteFile(yinf_ref, "/etc/yast.inf")
-        yinf = yinf_ref.value
+        adapt_install_inf
 
         # update "name" for proposal when it cannot be shown correctly
         if GetTextMode() && CJKLanguage(lang) && !CJKLanguage(@preselected)
-          @name = Ops.get_string(@languages_map, [lang, 1], lang)
+          @name = GetLanguagesMap(false).fetch(lang, [])[1] || lang
         end
       end
 

--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -2,9 +2,6 @@
 
 require_relative "test_helper"
 
-Yast.import "Mode"
-Yast::Mode.SetMode("normal")
-
 Yast.import "Language"
 
 describe "Language" do
@@ -67,22 +64,20 @@ describe "Language" do
 
   describe "#correct_language" do
     context "when called with a known, valid language" do
-      it "does nothing with the given language" do
+      it "returns the same unchanged language" do
         allow(subject).to receive(:valid_language?).with("known_language").and_return(true)
 
-        language = "known_language"
-        subject.correct_language(language)
+        language = subject.correct_language("known_language")
         expect(language).to eq("known_language")
       end
     end
 
     context "when called with an unknown language" do
-      it "reports an error and adjusts the given language to a default one" do
+      it "reports an error and returns the default fallback language" do
         allow(subject).to receive(:valid_language?).with("unknown_language").and_return(false)
         expect(Yast::Report).to receive(:Error).with(/unknown_language/)
 
-        language = "unknown_language"
-        subject.correct_language(language)
+        language = subject.correct_language("unknown_language")
         expect(language).to eq(Yast::LanguageClass::DEFAULT_FALLBACK_LANGUAGE)
       end
     end
@@ -133,7 +128,7 @@ describe "Language" do
 
     # This is a special case when we start installer in non-CJK language and then switch
     # to a CJK one (CJK == Chinese, Japanese, and Korean), in that case, needed fonts are
-    # not loaded and the UI just cna't display these CJK characters
+    # not loaded and the UI just can't display these CJK characters
     context "when called in text mode, in first stage, and user wants CJK language" do
       let(:new_language) { "ja_JP" }
 

--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -1,0 +1,151 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "Mode"
+Yast::Mode.SetMode("normal")
+
+Yast.import "Language"
+
+describe "Language" do
+  subject { Yast::Language }
+
+  let(:languages_map) {{
+    "de_DE" => [
+      "Deutsch",
+      "Deutsch",
+      ".UTF-8",
+      "@euro",
+      "German"
+    ],
+    "pt_BR" => [
+      "Português brasileiro",
+      "Portugues brasileiro",
+      ".UTF-8",
+      "",
+      "Portuguese (Brazilian)"
+    ],
+    # This is a "CJK" language
+    "ja_JP" => [
+      "日本語",
+      "Japanese",
+      ".UTF-8",
+      ".eucJP",
+      "Japanese"
+    ]
+  }}
+
+  before do
+    allow(subject).to receive(:languages_map).and_return(languages_map)
+    allow(subject).to receive(:GetLanguagesMap).and_return(languages_map)
+  end
+
+  describe "#integrate_inst_sys_extension" do
+    let(:new_language) { "de_DE" }
+
+    it "shows UI feedback and extends the inst-sys for selected language" do
+      allow(Yast::Popup).to receive(:ShowFeedback)
+      allow(Yast::Popup).to receive(:ClearFeedback)
+      expect(Yast::InstExtensionImage).to receive(:DownloadAndIntegrateExtension).with(/yast2-trans-.*/).and_return(true)
+      subject.integrate_inst_sys_extension(new_language)
+    end
+  end
+
+  describe "#valid_language?" do
+    context "when checking for a known, valid language" do
+      it "returns true" do
+        expect(subject.valid_language?("pt_BR")).to eq(true)
+      end
+    end
+
+    context "when checking for an unknown language" do
+      it "returns false" do
+        expect(subject.valid_language?("POSIX")).to eq(false)
+      end
+    end
+  end
+
+  describe "#correct_language" do
+    context "when called with a known, valid language" do
+      it "does nothing with the given language" do
+        allow(subject).to receive(:valid_language?).with("known_language").and_return(true)
+
+        language = "known_language"
+        subject.correct_language(language)
+        expect(language).to eq("known_language")
+      end
+    end
+
+    context "when called with an unknown language" do
+      it "reports an error and adjusts the given language to a default one" do
+        allow(subject).to receive(:valid_language?).with("unknown_language").and_return(false)
+        expect(Yast::Report).to receive(:Error).with(/unknown_language/)
+
+        language = "unknown_language"
+        subject.correct_language(language)
+        expect(language).to eq(Yast::LanguageClass::DEFAULT_FALLBACK_LANGUAGE)
+      end
+    end
+  end
+
+  describe "#Set" do
+    let(:new_language) { "pt_BR" }
+    let(:translated_language_name) { "Português brasileiro" }
+
+    before do
+      subject.language = "random_language"
+
+      allow(subject).to receive(:correct_language).and_return(new_language)
+      allow(subject).to receive(:GetTextMode).and_return(false)
+
+      expect(Yast::Encoding).to receive(:SetEncLang).with(new_language).and_return(true)
+    end
+
+    after do
+      # Language uses a constructor that loads several system settings and
+      # keeps them in memory
+      subject.language = "random_language"
+    end
+
+    context "when called in inst-sys" do
+      it "sets the new language, encoding integrates inst-sys extension and adapts install.inf" do
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+        allow(Yast::Mode).to receive(:mode).and_return("installation")
+        expect(subject).to receive(:integrate_inst_sys_extension).and_return(nil)
+        expect(subject).to receive(:adapt_install_inf).and_return(true)
+
+        subject.Set(new_language)
+        expect(subject.GetName).to eq(translated_language_name)
+      end
+    end
+
+    context "otherwise (running system, AutoYast config, etc.)" do
+      it "sets the new language and encoding" do
+        allow(Yast::Stage).to receive(:initial).and_return(false)
+        allow(Yast::Mode).to receive(:mode).and_return("normal")
+        expect(subject).not_to receive(:integrate_inst_sys_extension)
+        expect(subject).not_to receive(:adapt_install_inf)
+
+        subject.Set(new_language)
+        expect(subject.GetName).to eq(translated_language_name)
+      end
+    end
+
+    # This is a special case when we start installer in non-CJK language and then switch
+    # to a CJK one (CJK == Chinese, Japanese, and Korean), in that case, needed fonts are
+    # not loaded and the UI just cna't display these CJK characters
+    context "when called in text mode, in first stage, and user wants CJK language" do
+      let(:new_language) { "ja_JP" }
+
+      it "sets language name into its English translation" do
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+        allow(Yast::Mode).to receive(:mode).and_return("installation")
+        allow(subject).to receive(:GetTextMode).and_return(true)
+
+        subject.Set(new_language)
+        expect(subject.GetName).to eq("Japanese")
+      end
+    end
+  end
+
+end

--- a/language/test/Makefile.am
+++ b/language/test/Makefile.am
@@ -1,0 +1,12 @@
+#
+# Makefile.am for autoinstallation/test
+#
+
+TESTS = \
+    Language_test.rb
+
+TEST_EXTENSIONS = .rb
+RB_LOG_COMPILER = rspec
+VERBOSE = 1
+EXTRA_DIST = $(TESTS)
+

--- a/language/test/test_helper.rb
+++ b/language/test/test_helper.rb
@@ -1,0 +1,5 @@
+root_location = File.expand_path("../../", __FILE__)
+ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+
+require "yast"
+require "yast/rspec"

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug 10 14:27:49 CEST 2016 - locilka@suse.com
+
+- Added check for correct <language /> coming from an AutoYast
+  profile. When erroneous language is detected, then it's reported
+  and corrected to the default 'en_US' (bnc#991001).
+- 3.1.29
+
+-------------------------------------------------------------------
 Mon Jul 25 14:55:00 UTC 2016 - ancor@suse.com
 
 - Added support for Asturian variant of Spanish keyboard

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.28
+Version:        3.1.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
### Added check for importing invalid language (AutoYast)
- bnc#991001
- AutoYast did not report erroneous `<language/>` and used anything that came from the profile. That was causing problems, e.g., with systemctl output
- This patch adds a check for valid `<language/>` and if it's incorrect, error is reported and default language is used instead
- A little refactoring needed to be done to increase the readability of the code and also to make it testable with unit tests

![autoyast - check for incorrect language](https://cloud.githubusercontent.com/assets/463995/17555432/d96bf8c0-5f0f-11e6-845e-637ff130ab92.png)

### Added new test for Yast::Language
- Some pieces might look a bit crazy, but they are caused by the fact that Language uses a constructor

### What is not changed
- Refactoring was indeed limited, not everything that deserves fixing/refactoring was changed, but the code is better
- For instance, `adapt_install_inf` is a new function, but contains only a moved code, without refactoring
- Further refactoring was needed

### What's next
- We need to port this to SLE 12 SP2, but that needs to be done after this PR is merged