### PR TITLE
Fixed downloading language extensions in the installation

### DIFF
--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -464,7 +464,7 @@ module Yast
         lang = correct_language(lang)
 
         if Stage.initial && !Mode.test && !Mode.live_installation
-          integrate_inst_sys_extension(@language)
+          integrate_inst_sys_extension(lang)
         end
 
         GetLocales() if Builtins.size(@locales) == 0

--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -15,6 +15,13 @@ describe "Language" do
       "@euro",
       "German"
     ],
+    "de_ZU" => [
+      "Zulu Deutsch",
+      "Zulu Deutsch",
+      ".UTF-8",
+      ".deZU",
+      "Zulu German"
+    ],
     "pt_BR" => [
       "Português brasileiro",
       "Portugues brasileiro",
@@ -43,7 +50,9 @@ describe "Language" do
     it "shows UI feedback and extends the inst-sys for selected language" do
       allow(Yast::Popup).to receive(:ShowFeedback)
       allow(Yast::Popup).to receive(:ClearFeedback)
-      expect(Yast::InstExtensionImage).to receive(:DownloadAndIntegrateExtension).with(/yast2-trans-.*/).and_return(true)
+      # There are two or more de_* languages available, so it uses the full language ID
+      # instead of using only "de"
+      expect(Yast::InstExtensionImage).to receive(:DownloadAndIntegrateExtension).with(/yast2-trans-#{new_language}.*/).and_return(true)
       subject.integrate_inst_sys_extension(new_language)
     end
   end
@@ -106,7 +115,7 @@ describe "Language" do
       it "sets the new language, encoding integrates inst-sys extension and adapts install.inf" do
         allow(Yast::Stage).to receive(:initial).and_return(true)
         allow(Yast::Mode).to receive(:mode).and_return("installation")
-        expect(subject).to receive(:integrate_inst_sys_extension).and_return(nil)
+        expect(subject).to receive(:integrate_inst_sys_extension).with(new_language).and_return(nil)
         expect(subject).to receive(:adapt_install_inf).and_return(true)
 
         subject.Set(new_language)

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 19 14:47:20 CEST 2016 - locilka@suse.com
+
+- Fixed downloading language extensions in the installation
+  (bsc#994577)
+- 3.1.22.4
+
+-------------------------------------------------------------------
 Wed Aug 10 14:27:49 CEST 2016 - locilka@suse.com
 
 - Added check for correct <language /> coming from an AutoYast

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.22.3
+Version:        3.1.22.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- bsc#994577
- By mistake, extension for the previously selected language was always selected
- Test extended to check for the extension name that is being downloaded