### PR TITLE
 Corrected keyboard mapping for PT(BR), CZ, SK, Dvorak

### DIFF
--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -360,9 +360,7 @@ return ($[
 	// keyboard layout
 	_("Slovene"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "si.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses": "si.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -374,9 +372,7 @@ return ($[
 	// keyboard layout
 	_("Hungarian"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "hu.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses": "hu.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -388,9 +384,7 @@ return ($[
 	// keyboard layout
 	_("Polish"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "pl.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses": "pl.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -402,9 +396,7 @@ return ($[
 	// keyboard layout
 	_("Russian"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "ruwin_alt-UTF-8.map.gz",
-	    ],
+	    "pc104"	: $[ "ncurses": "ruwin_alt-UTF-8.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -463,21 +455,11 @@ return ($[
 	// keyboard layout
 	_("Croatian"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "hr.map.gz"
-	    ],
-	    "macintosh" : $[
-		    "ncurses"   : "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "hr.map.gz" ],
+	    "macintosh" : $[ "ncurses"  : "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
   "japanese":
@@ -533,21 +515,11 @@ return ($[
 	// keyboard layout
 	_("Ukrainian"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "ua-utf.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "ua-utf.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
 
@@ -555,21 +527,11 @@ return ($[
 	// keyboard layout
 	_("Khmer"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "khmer.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "khmer.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
 
@@ -577,21 +539,11 @@ return ($[
 	// keyboard layout
 	_("Korean"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "kr.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "kr.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
 
@@ -599,30 +551,18 @@ return ($[
 	// keyboard layout
 	_("Arabic"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "arabic.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "arabic.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
     "tajik": [
 	// keyboard layout
 	_("Tajik"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "tj_alt-UTF8.map.gz",
-	    ],
+	    "pc104"	: $[ "ncurses": "tj_alt-UTF8.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -634,21 +574,11 @@ return ($[
 	// keyboard layout
 	_("Traditional Chinese"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "us.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "us.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
 
@@ -656,21 +586,11 @@ return ($[
 	// keyboard layout
 	_("Simplified Chinese"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "us.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "us.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
 
@@ -678,42 +598,22 @@ return ($[
 	// keyboard layout
 	_("Romanian"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "ro.map.gz",
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "ro.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
     "us-int": [
 	// keyboard layout
 	_("US International"),
 	$[
-	    "pc104"	: $[
-		    "ncurses"	: "us-intl.map.gz"
-	    ],
-	    "macintosh" : $[
-		    "ncurses"	: "us-mac.map.gz"
-	    ],
-	    "type4"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5"	: $[
-		    "ncurses"	: "us.map.gz"
-	    ],
-	    "type5_euro": $[
-		    "ncurses"	: "us.map.gz"
-	    ],
+	    "pc104"	: $[ "ncurses"	: "us-intl.map.gz" ],
+	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
+	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
+	    "type5_euro": $[ "ncurses"	: "us.map.gz" ],
 	 ]
     ],
 ]);

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -230,7 +230,7 @@ return ($[
 	$[
 	    "pc104"	: $[ "ncurses": "us-intl.map.gz"],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
-	    "sparc64"	: $[ "type4": $[ "ncurses": "us.map.gz"],
+	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],
 	]

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -491,7 +491,7 @@ return ($[
 	// keyboard layout
 	_("Dvorak"),
 	$[
-	    "pc104"	: $[ "ncurses": "dvorak.map.gz" ],
+	    "pc104"	: $[ "ncurses": "us-dvorak.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -216,7 +216,7 @@ return ($[
 	// keyboard layout
 	_("Portuguese (Brazil)"),
 	$[
-	    "pc104"	: $[ "ncurses": "br-abnt2.map.gz"],
+	    "pc104"	: $[ "ncurses": "br-nativo.map.gz"],
 	    "macintosh" : $[ "ncurses": "br-abnt2.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -312,11 +312,8 @@ return ($[
 	// keyboard layout
 	_("Czech"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "cz-us-qwertz.map.gz",
-		    "compose" : "latin2"
-	    ],
-	    "macintosh" : $[ "ncurses": "cz-us-qwertz.map.gz" ],
+	    "pc104"	: $[ "ncurses": "cz.map.gz" ],
+	    "macintosh" : $[ "ncurses": "cz.map.gz" ],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],
@@ -327,10 +324,7 @@ return ($[
 	// keyboard layout
 	_("Czech (qwerty)"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "cz-lat2-us.map.gz",
-		    "compose" : "latin2"
-	    ],
+	    "pc104"	: $[ "ncurses": "cz-qwerty.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -342,10 +336,7 @@ return ($[
 	// keyboard layout
 	_("Slovak"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "sk-qwertz.map.gz",
-		    "compose" : "latin2"
-	    ],
+	    "pc104"	: $[ "ncurses": "sk.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
@@ -357,10 +348,7 @@ return ($[
 	// keyboard layout
 	_("Slovak (qwerty)"),
 	$[
-	    "pc104"	: $[
-		    "ncurses": "sk-qwerty.map.gz",
-		    "compose" : "latin2"
-	    ],
+	    "pc104"	: $[ "ncurses": "sk-qwerty.map.gz" ],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -217,7 +217,7 @@ return ($[
 	_("Portuguese (Brazil)"),
 	$[
 	    "pc104"	: $[ "ncurses": "br-nativo.map.gz"],
-	    "macintosh" : $[ "ncurses": "br-abnt2.map.gz"],
+	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],
@@ -313,7 +313,7 @@ return ($[
 	_("Czech"),
 	$[
 	    "pc104"	: $[ "ncurses": "cz.map.gz" ],
-	    "macintosh" : $[ "ncurses": "cz.map.gz" ],
+	    "macintosh" : $[ "ncurses": "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],


### PR DESCRIPTION
 Corrected Linux console keyboard mapping for Portuguese (Brazil), Czech, Slovak, Dvorak