### PR TITLE
Bsc1010938

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -556,8 +556,9 @@ module Yast
         return false # Error
       end
 
-      # Console command...
-      @ckb_cmd = Ops.add("/bin/loadkeys ", @keymap)
+      # Console command. It specifies all tty devices (bsc#1010938)
+      @tty_devices ||= Dir["/dev/tty*"].map { |d| "-C #{d}" }.join(" ")
+      @ckb_cmd = "/bin/loadkeys #{@tty_devices} #{keymap}"
 
       # X11 command...
       # do not try to run this with remote X display

--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -120,7 +120,7 @@ module Yast
       let(:chroot) { "spanish" }
 
       it "correctly sets all layout variables" do
-        expect(SCR).to execute_bash(/loadkeys ruwin_alt-UTF-8\.map\.gz/)
+        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.+ ruwin_alt-UTF-8\.map\.gz/)
 
         Keyboard.Set("russian")
         expect(Keyboard.current_kbd).to eq("russian")
@@ -132,7 +132,7 @@ module Yast
         stub_presence_of "/usr/sbin/xkbctrl"
         allow(XVersion).to receive(:binPath).and_return "/usr/bin"
 
-        expect(SCR).to execute_bash(/loadkeys tr\.map\.gz/)
+        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.+ tr\.map\.gz/)
         # Called twice, for SetConsole and SetX11
         expect(SCR).to execute_bash(/xkbctrl tr\.map\.gz/).twice do |p, cmd|
           dump_xkbctrl(:turkish, cmd.split("> ")[1])
@@ -143,7 +143,7 @@ module Yast
       end
 
       it "does not call setxkbmap if graphical system is not installed" do
-        expect(SCR).to execute_bash(/loadkeys ruwin_alt-UTF-8\.map\.gz/)
+        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.+ ruwin_alt-UTF-8\.map\.gz/)
         expect(SCR).to execute_bash(/xkbctrl ruwin_alt-UTF-8.map.gz/).never
         expect(SCR).to execute_bash(/setxkbmap/).never
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 21 15:50:47 UTC 2016 - igonzalezsosa@suse.com
+
+- Set keyboard layout properly on installation system (bsc#1010938)
+- 3.2.1
+
+-------------------------------------------------------------------
 Thu Nov  3 11:43:42 UTC 2016 - jreidinger@suse.com
 
 - language add-on no longer exists, so suggest to enable online

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
* Specify tty devices when calling to `loadkeys` in the `Keyboard` module.
* Fixes https://bugzilla.suse.com/show_bug.cgi?id=1001245.