### PR TITLE
Set timezone as read-only

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  9 10:09:53 UTC 2016 - igonzalezsosa@suse.com
+
+- Add support to set the timezone as read-only in the product's
+  control file
+- 3.1.32
+
+-------------------------------------------------------------------
 Wed Nov 23 13:41:41 CET 2016 - schubi@suse.de
 
 - Language has not been set. Taking language from zypp.

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -2,7 +2,7 @@
 Fri Dec  9 10:09:53 UTC 2016 - igonzalezsosa@suse.com
 
 - Add support to set the timezone as read-only in the product's
-  control file
+  control file (FATE#321754)
 - 3.1.32
 
 -------------------------------------------------------------------

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.31
+Version:        3.1.32
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/src/clients/inst_timezone.rb
+++ b/timezone/src/clients/inst_timezone.rb
@@ -23,6 +23,8 @@
 # $Id$
 module Yast
   class InstTimezoneClient < Client
+    include Yast::Logger
+
     def main
       Yast.import "UI"
       Yast.import "GetInstArgs"
@@ -34,6 +36,12 @@ module Yast
 
       @args = GetInstArgs.argmap
       @args["first_run"] = "yes" unless @args["first_run"] == "no"
+
+      if Timezone.readonly_timezone
+        # Do not run if timezone is readonly
+        log.info "Timezone is read-only for this product so the inst_timezone client is skipped"
+        return GetInstArgs.going_back ? :back : :next
+      end
 
       if Stage.initial &&
           Ops.greater_than(

--- a/timezone/src/clients/inst_timezone.rb
+++ b/timezone/src/clients/inst_timezone.rb
@@ -37,7 +37,7 @@ module Yast
       @args = GetInstArgs.argmap
       @args["first_run"] = "yes" unless @args["first_run"] == "no"
 
-      if Timezone.readonly_timezone
+      if Timezone.readonly
         # Do not run if timezone is readonly
         log.info "Timezone is read-only for this product so the inst_timezone client is skipped"
         return GetInstArgs.going_back ? :back : :next

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -445,7 +445,7 @@ module Yast
         # language --> timezone database, e.g. "de_DE" : "Europe/Berlin"
         new_timezone =
           if readonly
-            "UTC"
+            product_default_timezone
           else
             lang2tz = get_lang2tz
             Ops.get(lang2tz, Language.language, "")
@@ -1006,6 +1006,16 @@ module Yast
     # @return [Boolean] true if it's read-only; false otherwise.
     def readonly
       @readonly ||= ProductFeatures.GetBooleanFeature("globals", "readonly_timezone")
+    end
+
+    # Determines the default timezone for the current product
+    #
+    # If not timezone is set, "UTC" will be used.
+    #
+    # @return [String] timezone
+    def product_default_timezone
+      product_timezone = ProductFeatures.GetStringFeature("globals", "timezone")
+      product_timezone.empty? ? "UTC" : product_timezone
     end
 
     publish :variable => :timezone, :type => "string"

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -252,8 +252,8 @@ module Yast
     #
     def Set(zone, really)
       # Do not update the timezone if it's forced and it was already set
-      if readonly && !@timezone.empty?
-        log.info "Timezone is read-only and cannot be changed"
+      if (Mode.installation || Mode.update) && readonly && !@timezone.empty?
+        log.info "Timezone is read-only and cannot be changed during installation"
         return -1
       end
 

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -167,7 +167,7 @@ module Yast
       @systz_called = false
 
       # timezone is read-only
-      @readonly_timezone = nil
+      @readonly = nil
 
       Timezone()
     end
@@ -252,7 +252,7 @@ module Yast
     #
     def Set(zone, really)
       # Do not update the timezone if it's forced and it was already set
-      if readonly_timezone && !@timezone.empty?
+      if readonly && !@timezone.empty?
         log.info "Timezone is read-only and cannot be changed"
         return -1
       end
@@ -444,7 +444,7 @@ module Yast
       if Stage.initial && !Mode.live_installation
         # language --> timezone database, e.g. "de_DE" : "Europe/Berlin"
         new_timezone =
-          if readonly_timezone
+          if readonly
             "UTC"
           else
             lang2tz = get_lang2tz
@@ -1004,8 +1004,8 @@ module Yast
     # Determines whether timezone is read-only for the current product
     #
     # @return [Boolean] true if it's read-only; false otherwise.
-    def readonly_timezone
-      @readonly_timezone ||= ProductFeatures.GetBooleanFeature("globals", "readonly_timezone")
+    def readonly
+      @readonly ||= ProductFeatures.GetBooleanFeature("globals", "readonly_timezone")
     end
 
     publish :variable => :timezone, :type => "string"

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -254,23 +254,22 @@ module Yast
       # Do not update the timezone if it's forced and it was already set
       if (Mode.installation || Mode.update) && readonly && !@timezone.empty?
         log.info "Timezone is read-only and cannot be changed during installation"
-        return -1
+      else
+        # Set the new timezone internally
+        @timezone = zone
       end
 
       zmap = get_zonemap
 
-      # Set the new timezone internally
-      @timezone = zone
-
       sel = 0
       while Ops.less_than(sel, Builtins.size(zmap)) &&
-          !Builtins.haskey(Ops.get_map(zmap, [sel, "entries"], {}), zone)
+          !Builtins.haskey(Ops.get_map(zmap, [sel, "entries"], {}), @timezone)
         sel = Ops.add(sel, 1)
       end
 
       @name = Ops.add(
         Ops.add(Ops.get_string(zmap, [sel, "name"], ""), " / "),
-        Ops.get_string(zmap, [sel, "entries", zone], zone)
+        Ops.get_string(zmap, [sel, "entries", @timezone], @timezone)
       )
 
       # Adjust system to the new timezone.

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -254,7 +254,7 @@ module Yast
       # Do not update the timezone if it's forced and it was already set
       if readonly_timezone && !@timezone.empty?
         log.info "Timezone is read-only and cannot be changed"
-        return -1 # Not sure about this
+        return -1
       end
 
       zmap = get_zonemap
@@ -1001,6 +1001,13 @@ module Yast
       HTML.List(ret)
     end
 
+    # Determines whether timezone is read-only for the current product
+    #
+    # @return [Boolean] true if it's read-only; false otherwise.
+    def readonly_timezone
+      @readonly_timezone ||= ProductFeatures.GetBooleanFeature("globals", "readonly_timezone")
+    end
+
     publish :variable => :timezone, :type => "string"
     publish :variable => :hwclock, :type => "string"
     publish :variable => :default_timezone, :type => "string"
@@ -1043,11 +1050,6 @@ module Yast
     publish :function => :Import, :type => "boolean (map)"
     publish :function => :Export, :type => "map ()"
     publish :function => :Summary, :type => "string ()"
-
-    def readonly_timezone
-      @readonly_timezone ||= ProductFeatures.GetBooleanFeature("globals", "readonly_timezone")
-    end
-
   end
 
   Timezone = TimezoneClass.new

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -1008,6 +1008,9 @@ module Yast
       @readonly ||= ProductFeatures.GetBooleanFeature("globals", "readonly_timezone")
     end
 
+    # Product's default timezone when it's not defined in the control file.
+    FALLBACK_PRODUCT_DEFAULT_TIMEZONE = "UTC"
+
     # Determines the default timezone for the current product
     #
     # If not timezone is set, "UTC" will be used.
@@ -1015,7 +1018,7 @@ module Yast
     # @return [String] timezone
     def product_default_timezone
       product_timezone = ProductFeatures.GetStringFeature("globals", "timezone")
-      product_timezone.empty? ? "UTC" : product_timezone
+      product_timezone.empty? ? FALLBACK_PRODUCT_DEFAULT_TIMEZONE : product_timezone
     end
 
     publish :variable => :timezone, :type => "string"

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -87,7 +87,7 @@ describe Yast::Timezone do
       allow(Yast::FileUtils).to receive(:IsLink).with("/etc/localtime").and_return(false)
     end
 
-    it "returns the timezone index" do
+    it "returns the region number" do
       expect(subject.Set("Atlantic/Canary", false)).to eq(3)
     end
 
@@ -105,8 +105,8 @@ describe Yast::Timezone do
         allow(Yast::Mode).to receive(:installation).and_return(true)
       end
 
-      it "returns -1" do
-        expect(subject.Set("Atlantic/Canary", false)).to eq(-1)
+      it "returns the region number" do
+        expect(subject.Set("Atlantic/Canary", false)).to eq(10) # UTC
       end
 
       it "does not modify the timezone" do
@@ -118,8 +118,8 @@ describe Yast::Timezone do
     context "when timezone is read-only in a running system" do
       let(:readonly_timezone) { true }
 
-      it "returns the timezone index" do
-        expect(subject.Set("Atlantic/Canary", false)).to eq(3)
+      it "returns the region number" do
+        expect(subject.Set("Atlantic/Canary", false)).to eq(3) # Atlantic
       end
 
       it "modifies the timezone" do

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -82,4 +82,22 @@ describe Yast::Timezone do
       end
     end
   end
+
+  describe "#readonly" do
+    context "when timezone is read-only" do
+      let(:readonly_timezone) { true }
+
+      it "returns true" do
+        expect(subject.readonly).to eq(true)
+      end
+    end
+
+    context "when timezone is not read-only" do
+      let(:readonly_timezone) { false }
+
+      it "returns false" do
+        expect(subject.readonly).to eq(false)
+      end
+    end
+  end
 end

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -3,14 +3,18 @@
 require_relative "test_helper"
 
 Yast.import "Timezone"
+Yast.import "ProductFeatures"
 
 describe Yast::Timezone do
   let(:readonly_timezone) { false }
+  let(:default_timezone) { "" }
   let(:initial) { false }
 
   before do
     allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
       .with("globals", "readonly_timezone").and_return(readonly_timezone)
+    allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+      .with("globals", "timezone").and_return(default_timezone)
     allow(Yast::Stage).to receive(:initial).and_return(initial)
     Yast::Timezone.main
   end
@@ -57,12 +61,21 @@ describe Yast::Timezone do
   end
 
   describe "#timezone" do
+
     context "when timezone is read-only during installation" do
       let(:readonly_timezone) { true }
       let(:initial) { true }
 
       it "returns 'UTC'" do
         expect(subject.timezone).to eq("UTC")
+      end
+
+      context "and default timezone is set" do
+        let(:default_timezone) { "Atlantic/Canary" }
+
+        it "returns the default timezone" do
+          expect(subject.timezone).to eq("Atlantic/Canary")
+        end
       end
     end
   end

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -113,4 +113,20 @@ describe Yast::Timezone do
       end
     end
   end
+
+  describe "#product_default_timezone" do
+    let(:default_timezone) { "Atlantic/Canary" }
+
+    it "returns the globals/timezone feature" do
+      expect(subject.product_default_timezone).to eq(default_timezone)
+    end
+
+    context "when globals/timezone is not set" do
+      let(:default_timezone) { "" }
+
+      it "returns 'UTC'" do
+        expect(subject.product_default_timezone).to eq("UTC")
+      end
+    end
+  end
 end

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -5,6 +5,17 @@ require_relative "test_helper"
 Yast.import "Timezone"
 
 describe Yast::Timezone do
+  let(:readonly_timezone) { false }
+  let(:initial) { false }
+
+  before do
+    allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+      .with("globals", "readonly_timezone").and_return(readonly_timezone)
+    allow(Yast::Stage).to receive(:initial).and_return(initial)
+    Yast::Timezone.main
+  end
+
+  subject { Yast::Timezone }
 
   describe "#ProposeLocaltime" do
     subject { Yast::Timezone.ProposeLocaltime }
@@ -43,5 +54,32 @@ describe Yast::Timezone do
       expect(subject).to eq(false)
     end
     
+  end
+
+  describe "#timezone" do
+    context "when timezone is read-only during installation" do
+      let(:readonly_timezone) { true }
+      let(:initial) { true }
+
+      it "returns 'UTC'" do
+        expect(subject.timezone).to eq("UTC")
+      end
+    end
+  end
+
+  describe "#Set" do
+    context "when timezone is read-only during installation" do
+      let(:readonly_timezone) { true }
+      let(:initial) { true }
+
+      it "returns -1" do
+        expect(subject.Set("Atlantic/Canary", true)).to eq(-1)
+      end
+
+      it "does not modify the timezone" do
+        subject.Set("Atlantic/Canary", true)
+        expect(subject.timezone).to eq("UTC")
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements [Force timezone "UTC"](https://trello.com/c/1Mrvm2EH/781-5-casp-force-timezone-utc) PBI. It's not finished yet but feedback is welcome.

As a first approach, I've decided to add a new option to the control file readonly_timezone (perhaps I need a better name). If it's set to true, the timezone will be initialized to UTC and the Timezone.Set method will refuse to change it. I consider it a barrier to avoid accidental changes.