### PR TITLE
Added Y2Country::Widgets::KeyboardSelectionCombo (FATE#322328)

### DIFF
--- a/keyboard/src/lib/y2country/widgets.rb
+++ b/keyboard/src/lib/y2country/widgets.rb
@@ -26,7 +26,8 @@ Yast.import "Keyboard"
 
 module Y2Country
   module Widgets
-    class KeyboardSelection < CWM::SelectionBox
+    # Common parts for {KeyboardSelection} and {KeyboardSelectionCombo}.
+    module KeyboardSelectionBase
       # param default [String] ID for default keyboard layout if not selected.
       # Allowed values are defined in /usr/share/YaST2/data/keyboard_raw.ycp
       def initialize(default)
@@ -78,6 +79,18 @@ module Y2Country
             "installation and on the installed system.\n" \
             "</p>\n"
         )
+      end
+    end
+
+    class KeyboardSelection < CWM::SelectionBox
+      include KeyboardSelectionBase
+    end
+
+    class KeyboardSelectionCombo < CWM::ComboBox
+      include KeyboardSelectionBase
+
+      def opt
+        [:notify, :hstretch]
       end
     end
   end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 20 16:17:01 UTC 2017 - mvidner@suse.com
+
+- Added Y2Country::Widgets::KeyboardSelectionCombo (FATE#322328)
+- 3.1.33.4
+
+-------------------------------------------------------------------
 Mon Dec 19 13:03:21 UTC 2016 - igonzalezsosa@suse.com
 
 - Read keyboard and console fonts from different files depending

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.33.3
+Version:        3.1.33.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
It is wanted so that the widget fits in the all-in-one overview

- https://github.com/yast/yast-installation/pull/487
- https://fate.suse.com/322328

~~TODO: version, changes, dependencies~~