### PR TITLE
Docker at travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-ruby-bindings yast2-perl-bindings" -g "rspec:3.3.0 yast-rake gettext simplecov coveralls"
-script:
-    - rake check:syntax
-    - rake check:pot
-    - make -s -f Makefile.cvs
-    - make -s
-    - sudo make -s install
-    - make -s check
-    # evaluate code coverage for RSpec tests
-    - COVERAGE=1 rake test:unit
+sudo: required
+language: bash
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-country-image .
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-country-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby
+COPY . /usr/src/app
+

--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -130,7 +130,7 @@ module Yast
       let(:chroot) { "spanish" }
 
       it "correctly sets all layout variables" do
-        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.+ ruwin_alt-UTF-8\.map\.gz/)
+        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.* ruwin_alt-UTF-8\.map\.gz/)
 
         Keyboard.Set("russian")
         expect(Keyboard.current_kbd).to eq("russian")
@@ -142,7 +142,7 @@ module Yast
         stub_presence_of "/usr/sbin/xkbctrl"
         allow(XVersion).to receive(:binPath).and_return "/usr/bin"
 
-        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.+ tr\.map\.gz/)
+        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.* tr\.map\.gz/)
         # Called twice, for SetConsole and SetX11
         expect(SCR).to execute_bash(/xkbctrl tr\.map\.gz/).twice do |p, cmd|
           dump_xkbctrl(:turkish, cmd.split("> ")[1])
@@ -153,7 +153,7 @@ module Yast
       end
 
       it "does not call setxkbmap if graphical system is not installed" do
-        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.+ ruwin_alt-UTF-8\.map\.gz/)
+        expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.* ruwin_alt-UTF-8\.map\.gz/)
         expect(SCR).to execute_bash(/xkbctrl ruwin_alt-UTF-8.map.gz/).never
         expect(SCR).to execute_bash(/setxkbmap/).never
 


### PR DESCRIPTION
The test failed as at Docker there is only plain `/dev/tty` device which did not match the `\/dev\/tty.+` regexp.

*(Note: I tried mocking the `Dir["/dev/tty*"]` call at the test but that did not help as the value is cached and is probably initialized earlier by some other test. Moreover these tests are disabled during RPM build as they fail there and they would probably need some bigger cleanup anyway...)*