### PR TITLE
KeyboardSelection return nil in handle method. (bsc#1027171)

### DIFF
--- a/keyboard/src/lib/y2country/widgets.rb
+++ b/keyboard/src/lib/y2country/widgets.rb
@@ -58,6 +58,8 @@ module Y2Country
         Yast::Keyboard.Set(value)
         # mark that user approve selection
         Yast::Keyboard.user_decision = true
+
+        nil
       end
 
       def store

--- a/keyboard/test/widgets_test.rb
+++ b/keyboard/test/widgets_test.rb
@@ -20,7 +20,7 @@ describe Y2Country::Widgets::KeyboardSelection do
   it "changes keyboard layout when value changed" do
     expect(Yast::Keyboard).to receive(:Set)
 
-    subject.handle
+    expect(subject.handle).to eql(nil)
   end
 
   it "passes notify option to widget" do

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,3 +1,10 @@
+----------------------------------------------------------------
+Thu Mar  2 12:24:03 UTC 2017 - kanderssen@suse.com
+
+- Fixed value returned by the KeyboardSelection widget, avoiding
+  to trigger other widgets events (bsc#1027171).
+- 3.1.33.7
+
 -------------------------------------------------------------------
 Fri Feb 17 13:58:28 UTC 2017 - jreidinger@suse.com
 

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.33.6
+Version:        3.1.33.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
PBI: https://trello.com/c/P9uQmLRA/869-3-caasp-do-not-trigger-password-check-in-case-of-changing-keyboard-layout

Just return `nil` instead of `true` to avoid launch other widgets events or return from CWM.show

## After the fix no validation is raised

![keyboard_selection](https://cloud.githubusercontent.com/assets/7056681/23509853/1e67c24e-ff4f-11e6-851a-7efd67be5283.gif)