### PR TITLE
remove last remaining old storage reference

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 17 12:54:05 UTC 2017 - snwint@suse.com
+
+- remove last remaining old storage reference
+- 3.3.1
+
+-------------------------------------------------------------------
 Thu Mar 23 11:11:32 UTC 2017 - ancor@suse.com
 
 - Version temporarily bumped to 3.3.x to prioritize the

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.3.0
+Version:        3.3.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/src/clients/timezone.rb
+++ b/timezone/src/clients/timezone.rb
@@ -137,22 +137,9 @@ module Yast
       # create the wizard dialog
       Wizard.OpenOKDialog
 
-      # wrapper for storage calls, returns nil of yast2-storage is not installed
-      targets = Convert.convert(
-        WFM.call("wrapper_storage", ["GetTargetMap"]),
-        :from => "any",
-        :to   => "map <string, map>"
-      )
-      if targets != nil
-        partitions = Convert.convert(
-          WFM.call("wrapper_storage", ["GetWinPrimPartitions", [targets]]),
-          :from => "any",
-          :to   => "list <map>"
-        )
-        if partitions != nil && Ops.greater_than(Builtins.size(partitions), 0)
-          Timezone.windows_partition = true
-          Builtins.y2milestone("windows partition found")
-        end
+      if Timezone.system_has_windows?
+        Timezone.windows_partition = true
+        Builtins.y2milestone("windows partition found")
       end
 
       result = TimezoneDialog({})

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -1075,10 +1075,7 @@ module Yast
   protected
 
     def disk_analyzer
-      @disk_analyzer ||= begin
-        devicegraph = Y2Storage::StorageManager.instance.y2storage_probed
-        Y2Storage::DiskAnalyzer.new(devicegraph)
-      end
+      Y2Storage::StorageManager.instance.probed_disk_analyzer
     end
   end
 


### PR DESCRIPTION
'timezone' now also runs on the installed system. (It will crash when
run as non-root user due to storage-ng requiring root.)