### PR TITLE
Translation fix (bsc#1038077)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ test-driver
 /doc/css/
 /doc/js/
 /doc/Yast/
+/doc/Y2Country/
 /.yardoc/

--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -541,8 +541,12 @@ module Yast
     describe "#Summary" do
       it "retuns an HTML containing the current layout" do
         Keyboard.SetKeyboard("spanish")
+        # do not place translations to regexps or string interpolations
+        # see bsc#1038077 for details, make sure the translation does
+        # not contain special chars by accident
+        label = Regexp.escape(_("Spanish"))
         expect(Keyboard.Summary)
-          .to match /<li.*#{_("Spanish")}.*li>/
+          .to match /<li.*#{label}.*li>/
       end
     end
 


### PR DESCRIPTION
Ruby gettext cannot extract translatable texts from interpolated regexps.

- The fix is located in a test, the same string is correctly marked for translation in the real code at another place.
- This is only to avoid false positives later when grepping for translations in interpolations again.
- The version change is not required.
