### PR TITLE
Augment "Uzhgorod" (Europe/Uzhgorod) with "Ukraine (...)"

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 18 11:08:51 UTC 2017 - astieger@suse.com
+
+- Augment "Uzhgorod" (Europe/Uzhgorod) with "Ukraine ..." to
+  prevent an unknown country from being offered (bsc#1054917)
+- 4.0.1
+
+-------------------------------------------------------------------
 Thu Sep  7 11:25:21 UTC 2017 - jreidinger@suse.com
 
 - improve language selection to support also CaaSP needs
@@ -11,7 +18,6 @@ Wed Aug 30 10:24:33 UTC 2017 - igonzalezsosa@suse.com
 - Add a widget for language selection (fate#322276)
 - Move keyboard selection widget to lib/y2country/widgets
   directory
-- 3.3.2
 
 -------------------------------------------------------------------
 Mon Aug 14 09:44:58 UTC 2017 - snwint@suse.com

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-country
 #
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/src/data/timezone_raw.ycp
+++ b/timezone/src/data/timezone_raw.ycp
@@ -80,7 +80,7 @@ $[
 	"Europe/Stockholm" : _("Sweden"),
 	"Europe/Tallinn" : _("Estonia"),
 	"Europe/Tirane" : _("Albania"),
-	"Europe/Uzhgorod"	: _("Uzhgorod"),
+	"Europe/Uzhgorod"	: _("Ukraine (Uzhgorod)"),
 	"Europe/Vaduz" : _("Liechtenstein"),
 	"Europe/Vatican" : _("Vatican"),
 	"Europe/Vienna" : _("Austria"),


### PR DESCRIPTION
Augment "Uzhgorod" (Europe/Uzhgorod) with "Ukraine (...)"

	"Europe/Kiev" : _("Ukraine (Kiev)"),
	"Europe/Simferopol" : _("Ukraine (Simferopol)"),
	**"Europe/Uzhgorod" : _("Uzhgorod"),**
	"Europe/Zaporozhye" : _("Ukraine (Zaporozhye)"),

Fixes [bsc#1054917](https://bugzilla.opensuse.org/show_bug.cgi?id=1054917)