### PR TITLE
Do not use `--root` option for the `systemd-firstboot` call (bsc#1046436)

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -111,7 +111,6 @@ module Yast
       Yast.import "Directory"
       Yast.import "FileUtils"
       Yast.import "Initrd"
-      Yast.import "Installation"
       Yast.import "Label"
       Yast.import "Language"
       Yast.import "Linuxrc"
@@ -888,7 +887,8 @@ module Yast
 
       chomped_keymap = @keymap.chomp(".map.gz")
       cmd = if Stage.initial
-        "/usr/bin/systemd-firstboot --root #{Installation.destdir} --keymap '#{chomped_keymap}'"
+        # do not use --root option, SCR.Execute(".target...") already runs in chroot
+        "/usr/bin/systemd-firstboot --keymap '#{chomped_keymap}'"
       else
         "/usr/bin/localectl --no-convert set-keymap #{chomped_keymap}"
       end

--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -73,7 +73,7 @@ module Yast
 
         it "writes the configuration" do
           expect(SCR).to execute_bash_output(
-            /systemd-firstboot --root \/mnt --keymap 'es'$/
+            /systemd-firstboot --keymap 'es'$/
           )
           expect(AsciiFile).to receive(:AppendLine).with(anything, ["Keytable:", "es.map.gz"])
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 23 14:18:29 UTC 2017 - lslezak@suse.cz
+
+- Do not use `--root` option for the `systemd-firstboot` call,
+  SCR already runs it in the target chroot (bsc#1046436)
+- 4.0.4
+
+-------------------------------------------------------------------
 Fri Oct 20 11:32:05 UTC 2017 - lslezak@suse.cz
 
 - Use `systemd-firstboot` call for setting the keyboard in the

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The result is saved to `/mnt/mnt/...` which is wrong, the SCR already runs the command in the target chroot.

- 4.0.4