### PR TITLE
Display an error popup when saving the keyboard config fails

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -895,6 +895,8 @@ module Yast
       log.info "Making console keyboard persistent: #{cmd}"
       result = SCR.Execute(path(".target.bash_output"), cmd)
       if result["exit"] != 0
+        # TRANSLATORS: the "%s" is replaced by the executed command
+        Report.Error(_("Could not save the keyboard setting, the command\n%s\nfailed.") % cmd)
         log.error "Console keyboard configuration not written. Failed to execute '#{cmd}'"
         log.error "output: #{result.inspect}"
       end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 25 08:43:25 UTC 2017 - lslezak@suse.cz
+
+- Display an error popup when saving the keyboard config fails
+  (related to bsc#1046436)
+- 4.0.5
+
+-------------------------------------------------------------------
 Mon Oct 23 14:18:29 UTC 2017 - lslezak@suse.cz
 
 - Do not use `--root` option for the `systemd-firstboot` call,

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Related to [bsc#1046436](https://bugzilla.suse.com/show_bug.cgi?id=1046436)
- 4.0.5