### PR TITLE
Fixed saving X11 keyboard (bsc#1065264)

### DIFF
--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -100,11 +100,8 @@ module Yast
         let(:new_lang) { "russian" }
 
         it "writes the configuration" do
-          expect(SCR).to execute_bash(
-            /localectl --no-convert set-x11-keymap us,ru microsoftpro ,winkeys grp:ctrl_shift_toggle,grp_led:scroll$/
-          )
           expect(SCR).to execute_bash_output(
-            /localectl --no-convert set-keymap ruwin_alt-UTF-8$/
+            /localectl set-keymap ruwin_alt-UTF-8$/
           )
 
           Keyboard.Set("russian")

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 31 14:41:28 UTC 2017 - lslezak@suse.cz
+
+- Let the "localectl" to tool create the X11 keyboard configuration
+  (bsc#1065264)
+- 4.0.6
+
+-------------------------------------------------------------------
 Wed Oct 25 08:43:25 UTC 2017 - lslezak@suse.cz
 
 - Display an error popup when saving the keyboard config fails

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Oct 31 14:41:28 UTC 2017 - lslezak@suse.cz
 
-- Let the "localectl" to tool create the X11 keyboard configuration
+- Let the "localectl" tool to create the X11 keyboard configuration
   (bsc#1065264)
 - 4.0.6
 

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- The `localectl` tool can create the X11 configuration from the console setting (when the `--no-convert` option is not used), no need to reimplement the functionality in YaST
- See the details in the [man page](https://www.freedesktop.org/software/systemd/man/localectl.html#set-keymap%20MAP%20%5BTOGGLEMAP%5D)
- 4.0.6