### PR TITLE
Packaging fix - move language_dbus.rb file (bsc#1069119)

### DIFF
--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -553,7 +553,7 @@ module Yast
       @localed_conf  = Y2Country.read_locale_conf
       return nil if @localed_conf.nil?
       local_lang = @localed_conf["LANG"]
-      local_lang.sub!(/[.@].*$/, "")
+      local_lang.sub!(/[.@].*$/, "") if local_lang
       log.info("language from sysconfig: %{local_lang}")
       local_lang
     end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Nov 24 08:01:20 UTC 2017 - lslezak@suse.cz
+
+- Move the y2country/language_dbus.rb file to the
+  yast2-country-data subpackage where it is needed by Language.rb
+  (bsc#1069119)
+- 4.0.10
+
+-------------------------------------------------------------------
 Fri Nov 17 14:40:52 CET 2017 - schubi@suse.de
 
 - Fixed testcase dependencies. (Fix for previous change

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -100,7 +100,8 @@ install -m 0644 %SOURCE2 $RPM_BUILD_ROOT/usr/share/polkit-1/actions/
 %{yast_moduledir}/YaPI/TIME.pm
 %{yast_moduledir}/YaPI/LANGUAGE.pm
 %{yast_clientdir}/*.rb
-%{yast_libdir}/y2country
+%dir %{yast_libdir}/y2country
+%{yast_libdir}/y2country/widgets
 %{yast_ydatadir}/*.ycp
 %{yast_yncludedir}/keyboard/
 %{yast_yncludedir}/timezone/
@@ -130,5 +131,7 @@ functions (Language module)
 %dir %{yast_ydatadir}/languages
 %{yast_ydatadir}/languages/*.ycp
 %{yast_moduledir}/Language.rb
+%dir %{yast_libdir}/y2country
+%{yast_libdir}/y2country/language_dbus.rb
 
 %changelog


### PR DESCRIPTION
See  bug https://bugzilla.suse.com/show_bug.cgi?id=1069119

- The `y2country/language_dbus.rb` file packaged in `yast2-country` is required by [Language.rb](https://github.com/yast/yast-country/blob/master/language/src/modules/Language.rb#L38) which is for some reason located in `yast2-country-data`. If the package depends only on `yast2-country-data` then `Yast.import "Language"` fails because the `y2country/language_dbus.rb` file is missing.

- I have additionally added a `nil` check, I do not know why but in my TW system it failed with `nil` error. Just make sure it won't happen in some corner cases.


