### PR TITLE
Add simple language selection

### DIFF
--- a/language/src/Makefile.am
+++ b/language/src/Makefile.am
@@ -91,7 +91,8 @@ ylib_DATA = \
 
 ywidgetsdir = @ylibdir@/y2country/widgets
 ywidgets_DATA = \
-	lib/y2country/widgets/language_selection.rb
+	lib/y2country/widgets/language_selection.rb \
+	lib/y2country/widgets/simple_language_selection.rb
 
 desktop_DATA = \
   desktop/yast-language.desktop

--- a/language/src/lib/y2country/widgets/simple_language_selection.rb
+++ b/language/src/lib/y2country/widgets/simple_language_selection.rb
@@ -1,0 +1,112 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may find
+# current contact information at www.novell.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm/widget"
+
+Yast.import "Language"
+
+module Y2Country
+  module Widgets
+    # Language selection widget
+    #
+    # In contrast to {Y2Country::Widgets::LanguageSelection}, this modules does not
+    # modify the system language in any way.
+    class SimpleLanguageSelection < CWM::ComboBox
+      # @return [String] Default language code
+      attr_reader :default
+      # @return [String] List of languages to display (en_US, de_DE, etc.)
+      attr_reader :languages
+
+      # @param languages [Array<String>] List of languages to display (en_US, de_DE, etc.)
+      # @param default   [String]        Default language code
+      def initialize(languages, default)
+        textdomain "y2packager"
+        @languages = languages
+        @default = default
+        self.widget_id = "simple_language_selection"
+      end
+
+      # Widget label
+      #
+      # @return [String]
+      def label
+        _("&Language")
+      end
+
+      # Widget options
+      #
+      # Widget is forced to report immediatelly after value changed.
+      def opt
+        opts = [:notify]
+        opts << :disabled unless items.size > 1
+        opts
+      end
+
+      # [String] Default license language.
+      DEFAULT_LICENSE_LANG = "en_US".freeze
+
+      # Initialize to the given default language
+      #
+      # If the language is not in the list of options, it will try with the
+      # short code (for instance, "de" for "de_DE"). If it fails again, it
+      # initial value will be set to "en_US".
+      def init
+        languages = items.map(&:first)
+        new_value =
+          if languages.include?(default)
+            default
+          elsif default.include?("_")
+            short_code = default.split("_").first
+            languages.include?(short_code) ? short_code : nil
+          end
+
+        self.value = new_value || DEFAULT_LICENSE_LANG
+      end
+
+      # Widget help text
+      #
+      # @return [String]
+      def help
+        ""
+      end
+
+      # Return the options to be shown in the combobox
+      #
+      # @return [Array<Array<String,String>>] Array of languages in form [code, description]
+      def items
+        return @items if @items
+        languages_map = Yast::Language.GetLanguagesMap(false)
+        @items = languages.each_with_object([]) do |code, langs|
+          attrs = languages_map.key?(code) ? languages_map[code] : nil
+          lang, attrs = languages_map.find { |k, _v| k.start_with?(code) } if attrs.nil?
+
+          if attrs.nil?
+            log.warn "Not valid language '#{lang}'"
+            next
+          end
+
+          log.debug "Using language '#{lang}' instead of '#{code}'" if lang =! code
+          langs << [code, attrs[4]]
+        end
+        @items.sort_by! { |l| l[1] }
+      end
+    end
+  end
+end

--- a/language/test/Makefile.am
+++ b/language/test/Makefile.am
@@ -4,7 +4,8 @@
 
 TESTS = \
     Language_test.rb \
-    widgets/language_selection_test.rb
+    widgets/language_selection_test.rb \
+    widgets/simple_language_selection_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec --format doc

--- a/language/test/widgets/simple_language_selection_test.rb
+++ b/language/test/widgets/simple_language_selection_test.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../test_helper"
+require "y2country/widgets/simple_language_selection"
+require "cwm/rspec"
+require "y2packager/product"
+
+describe Y2Country::Widgets::SimpleLanguageSelection do
+  include_examples "CWM::AbstractWidget"
+
+  subject(:widget) { described_class.new(["de_DE", "en", "cs"], default) }
+
+  let(:default) { "en" }
+  let(:languages_map) do
+    {
+      "de_DE" => ["Deutsch", "Deutsch", ".UTF-8", "@euro", "German"],
+      "en_US" => ["English (US)", "English (US)", ".UTF-8", "", "English (US)"],
+      "es_ES" => ["Español", "Espanol", ".UTF-8", "@euro", "Spanish"],
+      "cs_CZ" => ["Čeština", "Cestina", ".UTF-8", "", "Czech"]
+    }
+  end
+
+  before do
+    allow(Yast::Language).to receive(:GetLanguagesMap).with(false)
+      .and_return(languages_map)
+  end
+
+  describe "#init" do
+    it "sets the widget's value to the default one" do
+      expect(widget).to receive(:value=).with(default)
+      widget.init
+    end
+
+    context "when full language code does not exist" do
+      let(:default) { "cs_CZ" }
+
+      it "tries using the short language code" do
+        expect(widget).to receive(:value=).with("cs")
+        widget.init
+      end
+
+      context "and short language code does not exist" do
+        let(:default) { "es" }
+
+        it "tries to the default 'en_US'" do
+          expect(widget).to receive(:value=).with("en_US")
+          widget.init
+        end
+      end
+    end
+  end
+
+  describe "#items" do
+    it "contains only given languages" do
+      expect(widget.items).to eq([
+        ["cs", "Czech"],
+        ["en", "English (US)"],
+        ["de_DE", "German"]
+      ])
+    end
+  end
+
+  describe "#opt" do
+    it "sets the :notify option" do
+      expect(widget.opt).to eq([:notify])
+    end
+
+    context "when there is only one option" do
+      let(:languages_map) do
+        { "en_US" => ["English (US)", "English (US)", ".UTF-8", "", "English (US)"] }
+      end
+
+      it "sets the :disabled option" do
+        expect(widget.opt).to include(:disabled)
+      end
+    end
+  end
+end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 14 12:26:10 UTC 2018 - igonzalezsosa@suse.com
+
+- Add a simple widget to choose a language from a given list
+  (related to FATE#322276).
+- 4.0.21
+
+-------------------------------------------------------------------
 Fri Feb  9 16:41:49 UTC 2018 - ancor@suse.com
 
 - Keyboard: don't try to set the keyboard map for AMBA devices,
@@ -8,7 +15,7 @@ Fri Feb  9 16:41:49 UTC 2018 - ancor@suse.com
 -------------------------------------------------------------------
 Tue Jan 30 12:50:29 UTC 2018 - jreidinger@suse.com
 
-- Lnaguage: nicer handling of dbus timeout (bsc#1076804)
+- Language: nicer handling of dbus timeout (bsc#1076804)
 - 4.0.19
 
 -------------------------------------------------------------------

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.0.20
+Version:        4.0.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Add a widget which allows selecting a language from a given list. The main difference with `Y2Country::Widgets::LanguageSelection` is that it does not make any change to the system (like changing the Language).

PBI: https://trello.com/c/VjEpcE8x/