### PR TITLE
Pass absolute paths to "yard"

### DIFF
--- a/keyboard/doc/autodocs/Makefile.am
+++ b/keyboard/doc/autodocs/Makefile.am
@@ -1,3 +1,6 @@
 # Makefile.am for YCP module .../doc/autodocs
 
+# set the path to the sources, the default is $(abs_top_srcdir)/src/...
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/keyboard/src/modules/*.rb $(abs_top_srcdir)/keyboard/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/language/doc/autodocs/Makefile.am
+++ b/language/doc/autodocs/Makefile.am
@@ -1,3 +1,6 @@
 # Makefile.am for YCP module .../doc/autodocs
 
+# set the path to the sources, the default is $(abs_top_srcdir)/src/...
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/language/src/modules/*.rb $(abs_top_srcdir)/language/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jul 24 15:26:47 UTC 2018 - lslezak@suse.cz
+
+- Pass absolute paths to "yard", relative paths do not work anymore
+  because of a security update (bsc#1070263, CVE-2017-17042)
+- This is a yast2-country specific fix because it uses a different
+  directory layout than the other YaST packages.
+- 3.1.22.2
+
+-------------------------------------------------------------------
 Thu Oct  1 14:59:57 CEST 2015 - locilka@suse.com
 
 - Allocate space for "Other Settings" button proportionally to its

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.1.22.1
+Version:        3.1.22.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/doc/autodocs/Makefile.am
+++ b/timezone/doc/autodocs/Makefile.am
@@ -1,3 +1,6 @@
 # Makefile.am for YCP module .../doc/autodocs
 
+# set the path to the sources, the default is $(abs_top_srcdir)/src/...
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/timezone/src/modules/*.rb $(abs_top_srcdir)/timezone/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami


### PR DESCRIPTION
For `yast2-country` we need a specific fix, the generic fix in `yast2-devtools` (https://github.com/yast/yast-devtools/pull/130) does not work here because of a different directory layout (the sources are in several subdirectories).

See https://github.com/yast/yast-devtools/pull/130 for more details.