### PR TITLE
Firstboot: Fallback to the default language if it is empty when reading it from sysconfig

### DIFF
--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -545,7 +545,7 @@ module Yast
       nil
     end
 
-    # Read the RC_LANG value from sysconfig and exctract language from it
+    # Read the RC_LANG value from sysconfig and extract language from it
     # @return language
     def ReadSysconfigLanguage
       local_lang = Misc.SysconfigRead(
@@ -635,6 +635,10 @@ module Yast
         SetDefault() # also default
       else
         local_lang = ReadSysconfigLanguage()
+        # Fallback to the default if not defined one (bsc#1103397)
+        if Stage.firstboot && local_lang.empty?
+          local_lang = DEFAULT_FALLBACK_LANGUAGE
+        end
         QuickSet(local_lang)
         SetDefault() # also default
         if Mode.live_installation || Stage.firstboot

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,3 +1,10 @@
+-------------------------------------------------------------------
+Tue Aug  7 12:00:24 UTC 2018 - knut.anderssen@suse.com
+
+- Fallback to the default language during the firstboot if the
+  sysconfig RC_LANG is empty (bsc#1103397)
+- 3.2.15
+
 ----------------------------------------------------------------
 Wed Dec 13 13:48:06 CET 2017 - schubi@suse.de
 

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.2.14
+Version:        3.2.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1103397

With `.etc.sysconfig.language.RC_LANG = ""`

## Before the fix

![screenshot_sle12sp4_2018-08-07_14 03 20](https://user-images.githubusercontent.com/7056681/43777419-ada41952-9a4a-11e8-921a-1a674204b566.png)

## After the fix

![screenshot_sle12sp4_2018-08-07_13 00 01](https://user-images.githubusercontent.com/7056681/43777376-8c26840e-9a4a-11e8-97a4-a2a1379beb4a.png)