### PR TITLE
Set only system date if no HW clock available

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 27 10:37:48 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Set only system time if no hardware clock available (bsc#1103744)
+- 3.2.16
+
+-------------------------------------------------------------------
 Tue Aug  7 12:00:24 UTC 2018 - knut.anderssen@suse.com
 
 - Fallback to the default language during the firstboot if the

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.2.15
+Version:        3.2.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -472,51 +472,70 @@ module Yast
 
     # Set the new time and date given by user
     def SetTime(year, month, day, hour, minute, second)
-      if !Arch.s390
-        date = Builtins.sformat(
-          " --date=\"%1/%2/%3 %4:%5:%6\" ",
-          month,
-          day,
-          year,
-          hour,
-          minute,
-          second
-        )
-        cmd = ""
-        if Ops.greater_than(Builtins.size(@timezone), 0) &&
-            @hwclock != "--localtime"
-          cmd = Ops.add(Ops.add("TZ=", @timezone), " ")
-        end
-        cmd = Ops.add(
-          Ops.add(Ops.add(cmd, "/sbin/hwclock --set "), @hwclock),
-          date
-        )
-        Builtins.y2milestone("SetTime cmd %1", cmd)
-        SCR.Execute(path(".target.bash"), cmd)
-        cmd = Ops.add("/sbin/hwclock --hctosys ", @hwclock)
-        Builtins.y2milestone("SetTime cmd %1", cmd)
-        SCR.Execute(path(".target.bash"), cmd)
-        # actually, it was probably not called, but do not let it change the time again after manual change
-        @systz_called = true
-      end
+      return nil if Arch.s390
 
+      timedate = "#{month}/#{day}/#{year} #{hour}:#{minute}:#{second}"
+
+      if set_hwclock(timedate)
+        sync_hwclock_to_system_time
+      else
+        # No hardware clock available (bsc#1103744)
+        log.info("Fallback: Leaving HW clock untouched, setting only system time")
+        set_system_time(timedate)
+      end
       nil
     end
 
     # Set the Hardware Clock to the current System Time.
     def SystemTime2HWClock
-      if !Arch.s390
-        cmd = ""
-        if Ops.greater_than(Builtins.size(@timezone), 0) &&
-            @hwclock != "--localtime"
-          cmd = Ops.add(Ops.add("TZ=", @timezone), " ")
-        end
-        cmd = Ops.add("/sbin/hwclock --systohc ", @hwclock)
-        Builtins.y2milestone("cmd %1", cmd)
-        SCR.Execute(path(".target.bash"), cmd)
-      end
+      return nil if Arch.s390
 
+      cmd = tz_prefix + "/sbin/hwclock --systohc #{@hwclock}"
+      log.info("cmd #{cmd}")
+      SCR.Execute(path(".target.bash"), cmd)
       nil
+    end
+
+    # Set the hardware clock with the given date.
+    # @param timedate [String]
+    # @return [Bool] true if success, false if error
+    #
+    def set_hwclock(date)
+      cmd = tz_prefix + "/sbin/hwclock --set #{@hwclock} --date=\"#{date}\""
+      log.info("set_hwclock: #{cmd}")
+      SCR.Execute(path(".target.bash"), cmd) == 0
+    end
+
+    # Synchronize the hardware clock to the system time
+    #
+    def sync_hwclock_to_system_time
+      cmd = "/sbin/hwclock --hctosys #{@hwclock}"
+      log.info("sync_hwclock_to_system_time: #{cmd}")
+      SCR.Execute(path(".target.bash"), cmd)
+      @systz_called = true
+    end
+
+    # Set only the system time (leaving the hardware clock untouched)
+    # @param timedate [String]
+    #
+    def set_system_time(timedate)
+      cmd = "/usr/bin/date --set=\"#{timedate}\""
+      log.info("set_system_time: #{cmd}")
+      SCR.Execute(path(".target.bash"), cmd)
+    end
+
+    # Return a "TZ=... " prefix for commands such as "hwclock" or "date" to set
+    # the time zone environment variable temporarily for the duration of one
+    # command.
+    #
+    # If nonempty, this will append a blank as a separator.
+    #
+    # @return [String]
+    #
+    def tz_prefix
+      return "" if @hwclock == "--localtime"
+      return "" if @timezone.empty?
+      "TZ=#{@timezone} "
     end
 
 
@@ -637,16 +656,12 @@ module Yast
             Builtins.y2milestone("GetDateTime ds %1 diff %2", ds, @diff)
           end
         end
-        cmd = ""
-        cmd = Builtins.sformat("TZ=%1 ", @timezone) if @hwclock != "--localtime"
-        cmd = Ops.add(
-          cmd,
+        cmd = tz_prefix +
           Builtins.sformat(
             "/bin/date \"%1\" \"--date=now %2sec\"",
             date_format,
             Ops.multiply(ds, @diff)
           )
-        )
       else
         cmd = Builtins.sformat("/bin/date \"%1\"", date_format)
       end

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -632,11 +632,7 @@ module Yast
         "+%c" :
         "+%Y-%m-%d - %H:%M:%S"
 
-      Builtins.y2milestone(
-        "GetDateTime hwclock %1 real:%2",
-        @hwclock,
-        real_time
-      )
+      log.info("GetDateTime hwclock: #{@hwclock} real: #{real_time}")
       if !real_time && !Mode.config
         ds = 0
         if @diff != 0
@@ -644,7 +640,7 @@ module Yast
             SCR.Execute(path(".target.bash_output"), "date +%z")
           )
           tzd = Ops.get_string(out2, "stdout", "")
-          Builtins.y2milestone("GetDateTime tcd=%1", tzd)
+          log.info("GetDateTime tzd: #{tzd}")
           t = Builtins.tointeger(String.CutZeros(Builtins.substring(tzd, 1, 2)))
           if t != nil
             ds = Ops.add(ds, Ops.multiply(t, 3600))
@@ -653,7 +649,7 @@ module Yast
             )
             ds = Ops.add(ds, Ops.multiply(t, 60))
             ds = Ops.unary_minus(ds) if Builtins.substring(tzd, 0, 1) == "-"
-            Builtins.y2milestone("GetDateTime ds %1 diff %2", ds, @diff)
+            log.info("GetDateTime ds: #{ds} diff: #{@diff}")
           end
         end
         cmd = tz_prefix +
@@ -665,11 +661,11 @@ module Yast
       else
         cmd = Builtins.sformat("/bin/date \"%1\"", date_format)
       end
-      Builtins.y2milestone("GetDateTime cmd=%1", cmd)
+      log.info("GetDateTime cmd: #{cmd}")
       out = Convert.to_map(SCR.Execute(path(".target.bash_output"), cmd))
       local_date = Builtins.deletechars(Ops.get_string(out, "stdout", ""), "\n")
 
-      Builtins.y2milestone("GetDateTime local_date='%1'", local_date)
+      log.info("GetDateTime local_date: '#{local_date}'")
 
       local_date
     end

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -519,7 +519,7 @@ module Yast
     # @param timedate [String]
     #
     def set_system_time(timedate)
-      cmd = "/usr/bin/date --set=\"#{timedate}\""
+      cmd = tz_prefix + "/usr/bin/date --set=\"#{timedate}\""
       log.info("set_system_time: #{cmd}")
       SCR.Execute(path(".target.bash"), cmd)
     end


### PR DESCRIPTION
## Trello

https://trello.com/c/Hxd4d3qV/301-sles12-sp4-p2-1103744-rpi-unable-to-set-time-manually-in-firstboot-no-rtc-hw

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1103744

## Problem

If a hardware clock is not available (for example on a RasPi), setting the date and time during installation has no effect: It tries to set it via the `hwclock` command. If that fails, it does not set it at all.

## Solution

If that `hwclock` command for setting date and time fails (and only then), use the good old `date` command to set at least the system clock.

This is done independently of RasPi or whatever hardware; it might as well fail on other hardware.