### PR TITLE
provide better API for getting keyboard map info (fate#325748)

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -434,8 +434,27 @@ module Yast
       Builtins.union(base_lang2keyboard, Language.GetLang2KeyboardMap(true))
     end
 
+    # Get the default key map for selected language
+    #
+    # @param   the locale, e.g. cs_CZ
+    #
+    # @return the expected key map, e.g. cz-us-qwertz.map.gz
+    #
+    def GetKeymapForLanguage(sys_language)
+      keyboard = GetKeyboardForLanguage(sys_language, "us")
+      keyboards = get_reduced_keyboard_db
 
+      Builtins.y2debug("reduced kbd db %1", keyboards)
+      # Get the entry from the reduced local map for the given language.
+      #
+      kbd_descr = Ops.get_list(keyboards, keyboard, [])
+      Builtins.y2milestone( "Description for keyboard <%1>: <%2>", keyboard, kbd_descr)
 
+      if kbd_descr != [] # keyboard found
+        return Ops.get_string(kbd_descr, [1, "ncurses"], "us.map.gz")
+      end
+      return "us.map.gz"
+    end
 
     # GetKeyboardForLanguage()
     #
@@ -1320,6 +1339,7 @@ module Yast
     publish :function => :SetKeyboardForLanguage, :type => "void (string)"
     publish :function => :SetKeyboardForLang, :type => "void (string)"
     publish :function => :SetKeyboardDefault, :type => "void ()"
+    publish :function => :GetKeymapForLanguage, :type => "string(string)"
     publish :function => :Import, :type => "boolean (map, ...)"
     publish :function => :Export, :type => "map ()"
     publish :function => :Summary, :type => "string ()"

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -2,6 +2,7 @@
 Fri Nov  9 07:52:29 UTC 2018 - jsrain@suse.cz
 
 - provide better API for getting keyboard map info (fate#325748)
+- 4.1.1
 
 -------------------------------------------------------------------
 Fri Oct 26 13:21:47 UTC 2018 - jreidinger@suse.com

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Nov  9 07:52:29 UTC 2018 - jsrain@suse.cz
+
+- provide better API for getting keyboard map info (fate#325748)
+
+-------------------------------------------------------------------
 Fri Oct 26 13:21:47 UTC 2018 - jreidinger@suse.com
 
 - Console: Use empty string instead of none for FONTMAP

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Sorry for no test suite and code looking old; the goal is to provide a reasonable way to fetch the keyboard map information so that JeOS can keep its locale database in sync with the one from YaST (without having to call the "SetKeyboard" function).

Long-term, this the data stored with the modules should be reviewed, converted to a reasonable format and given a better structure ... but this is for longer time period.