### PR TITLE
Installation ntp first run: Write and sync the default config if enabled in the control file

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,3 +1,8 @@
+-------------------------------------------------------------------
+Tue May 15 12:36:33 UTC 2018 - jreidinger@suse.com
+
+- Do not use opensuse ntp pool servers for SLE (bsc#1090168)
+
 ----------------------------------------------------------------
 Wed Dec 13 13:48:06 CET 2017 - schubi@suse.de
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Sat Nov 10 08:31:44 UTC 2018 - knut.anderssen@suse.com
+
+- Timezone: Since ntp-client does not write the config anymore when
+  called for syncing only, we need to remove the 'ntpdate_only'
+  parameter in order to continue proposing a default when it is
+  enabled in the control file (bsc#1108497).
+- 3.2.15
+
+-------------------------------------------------------------------
 Tue May 15 12:36:33 UTC 2018 - jreidinger@suse.com
 
 - Do not use opensuse ntp pool servers for SLE (bsc#1090168)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        3.2.14
+Version:        3.2.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/timezone/src/include/timezone/dialogs.rb
+++ b/timezone/src/include/timezone/dialogs.rb
@@ -47,6 +47,7 @@ module Yast
       Yast.import "NetworkService"
       Yast.import "Package"
       Yast.import "Popup"
+      Yast.import "Product"
       Yast.import "ProductFeatures"
       Yast.import "Service"
       Yast.import "Stage"
@@ -573,22 +574,21 @@ module Yast
         # true by default (fate#303520)
         @ntp_used = true
         # configure NTP client
-        Builtins.srandom
-        @ntp_server = Builtins.sformat(
-          "%1.opensuse.pool.ntp.org",
-          Builtins.random(4)
-        )
+        # to prevent misusage of ntp.org we need to distinguish opensuse and SLE usage
+        base_products = Product.FindBaseProducts
+        if base_products.any? { |p| p["name"] =~ /openSUSE/i }
+          servers = (0..3).map { |i| "#{i}.opensuse.pool.ntp.org" }
+        else
+          servers = (0..3).map { |i| "#{i}.novell.pool.ntp.org" }
+        end
+        @ntp_server = servers.sample
         argmap = {
           "server"       => @ntp_server,
           # FIXME ntp-client_proposal doesn't understand 'servers' yet
-          "servers"      => [
-            "0.opensuse.pool.ntp.org",
-            "1.opensuse.pool.ntp.org",
-            "2.opensuse.pool.ntp.org",
-            "3.opensuse.pool.ntp.org"
-          ],
+          "servers"      => servers,
           "ntpdate_only" => true
         }
+
         rv = Convert.to_symbol(ntp_call("Write", argmap))
         if rv == :invalid_hostname
           Builtins.y2warning("Invalid NTP server hostname %1", @ntp_server)

--- a/timezone/src/include/timezone/dialogs.rb
+++ b/timezone/src/include/timezone/dialogs.rb
@@ -586,7 +586,6 @@ module Yast
           "server"       => @ntp_server,
           # FIXME ntp-client_proposal doesn't understand 'servers' yet
           "servers"      => servers,
-          "ntpdate_only" => true
         }
 
         rv = Convert.to_symbol(ntp_call("Write", argmap))


### PR DESCRIPTION
Description
--------------

In this [PR](https://github.com/yast/yast-ntp-client/pull/121), we avoided to write when the client was calling for syncing only.

So this PR is for removing the sync only parameter for also writing during the first run of the dialog in an installation.
