### PR TITLE
Force the installer to use fbiterm

### DIFF
--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -258,7 +258,6 @@ module Yast
     # Fill the map with English names of languages
     def FillEnglishNames
       old_lang = WFM.GetLanguage()
-      return if old_lang == DEFAULT_FALLBACK_LANGUAGE # will be filled in on first start
       if @use_utf8
         WFM.SetLanguage(DEFAULT_FALLBACK_LANGUAGE, "UTF-8")
       else
@@ -1333,38 +1332,35 @@ module Yast
     end
 
     # Set current YaST language to English if method for showing text in
-    # current language is not supported (usually for CJK languages)
-    # See http://bugzilla.novell.com/show_bug.cgi?id=479529 for discussion
+    # current language is not supported:
+    #
+    # * CJK languages when not using fbiterm
+    # * other unsupported languages when not running on fbiterm
+    #
+    # See http://bugzilla.suse.com/show_bug.cgi?id=479529 for discussion
     # @boolean show_popup if information popup about the change should be shown
     # @return true if UI language was changed
     def SwitchToEnglishIfNeeded(show_popup)
-      if Stage.normal
-        Builtins.y2milestone("no language switching in normal stage")
-        return false
-      end
-      if GetTextMode() &&
-          # current language is CJK
-          CJKLanguage(@language) &&
-          # fbiterm is not running
-          Builtins.getenv("TERM") != "iterm"
-        if show_popup
-          # popup message (user selected CJK language in text mode)
-          Popup.Message(
-            _(
-              "The selected language cannot be used in text mode. English is used for\ninstallation, but the selected language will be used for the new system."
-            )
-          )
-        end
-        WfmSetGivenLanguage(DEFAULT_FALLBACK_LANGUAGE)
-        return true
-      end
-      false
+      return false if Stage.normal || supported_language?(@language)
+
+      show_popup_early = supported_language?(WFM.GetLanguage())
+      show_fallback_to_english_warning if show_popup && show_popup_early
+      WfmSetGivenLanguage(DEFAULT_FALLBACK_LANGUAGE)
+      show_fallback_to_english_warning if show_popup && !show_popup_early
+      true
+    end
+
+    # Determines whether the language is supported or not
+    #
+    # @note To be used in instsys
+    def supported_language?(lang)
+      return true unless GetTextMode()
+      (fbiterm? && supported_by_fbiterm?(lang)) || !(fbiterm? || CJKLanguage(lang))
     end
 
     def GetCurrentLocaleString
       GetLocaleString @language
     end
-
 
     publish :variable => :language, :type => "string"
     publish :variable => :language_on_entry, :type => "string"
@@ -1414,6 +1410,36 @@ module Yast
     publish :function => :GetLanguageItems, :type => "list <term> (symbol)"
     publish :function => :CheckLanguagesSupport, :type => "void (string)"
     publish :function => :SwitchToEnglishIfNeeded, :type => "boolean (boolean)"
+
+  private
+
+    # @return [Array<String>] List of languages which are not supported by fbiterm
+    UNSUPPORTED_FBITERM_LANGS = [
+      "ar_EG", "bn_BD", "gu_IN", "hi_IN", "km_KH", "mr_IN", "pa_IN", "ta_IN", "th_TH"
+].freeze
+
+    # Determines whether the language is supported by fbiterm
+    # @param lang [String] Language code
+    # @return [Boolean]
+    def supported_by_fbiterm?(lang)
+      code, _ = lang.split(".")
+      !UNSUPPORTED_FBITERM_LANGS.include?(code)
+    end
+
+    # Determines whether the installer is running on fbiterm
+    #
+    # @return [Boolean]
+    def fbiterm?
+      Builtins.getenv("TERM") == "iterm"
+    end
+
+    def show_fallback_to_english_warning
+      Popup.Message(
+        _(
+          "The selected language cannot be used in text mode. English is used for\ninstallation, but the selected language will be used for the new system."
+        )
+      )
+    end
   end
 
   Language = LanguageClass.new

--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -1434,7 +1434,7 @@ module Yast
     end
 
     def show_fallback_to_english_warning
-      Popup.Message(
+      Report.Message(
         _(
           "The selected language cannot be used in text mode. English is used for\ninstallation, but the selected language will be used for the new system."
         )

--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -256,8 +256,9 @@ module Yast
     end
 
     # Fill the map with English names of languages
-    def FillEnglishNames(lang)
-      return if lang == DEFAULT_FALLBACK_LANGUAGE # will be filled in on first start
+    def FillEnglishNames
+      old_lang = WFM.GetLanguage()
+      return if old_lang == DEFAULT_FALLBACK_LANGUAGE # will be filled in on first start
       if @use_utf8
         WFM.SetLanguage(DEFAULT_FALLBACK_LANGUAGE, "UTF-8")
       else
@@ -267,9 +268,9 @@ module Yast
         Ops.set(@english_names, code, Ops.get_string(info, 4, ""))
       end
       if @use_utf8
-        WFM.SetLanguage(lang, "UTF-8")
+        WFM.SetLanguage(old_lang, "UTF-8")
       else
-        WFM.SetLanguage(lang)
+        WFM.SetLanguage(old_lang)
       end
 
       nil
@@ -630,7 +631,7 @@ module Yast
             lang
           )
         end
-        FillEnglishNames(lang)
+        FillEnglishNames()
         Set(lang) # coming from /etc/install.inf
         SetDefault() # also default
       else
@@ -638,7 +639,7 @@ module Yast
         QuickSet(local_lang)
         SetDefault() # also default
         if Mode.live_installation || Stage.firstboot
-          FillEnglishNames(local_lang)
+          FillEnglishNames()
         end
       end
       if Ops.greater_than(

--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -1414,16 +1414,14 @@ module Yast
   private
 
     # @return [Array<String>] List of languages which are not supported by fbiterm
-    UNSUPPORTED_FBITERM_LANGS = [
-      "ar_EG", "bn_BD", "gu_IN", "hi_IN", "km_KH", "mr_IN", "pa_IN", "ta_IN", "th_TH"
-].freeze
+    UNSUPPORTED_FBITERM_LANGS = ["ar", "bn", "gu", "hi", "km", "mr", "pa", "ta", "th"].freeze
 
     # Determines whether the language is supported by fbiterm
     # @param lang [String] Language code
     # @return [Boolean]
     def supported_by_fbiterm?(lang)
-      code, _ = lang.split(".")
-      !UNSUPPORTED_FBITERM_LANGS.include?(code)
+      code, _ = lang.split("_")
+      UNSUPPORTED_FBITERM_LANGS.none?(code)
     end
 
     # Determines whether the installer is running on fbiterm

--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -264,12 +264,12 @@ describe "Language" do
         end
 
         it "displays an error message if asked to do so" do
-          allow(Yast::Popup).to receive(:Message).with(/selected language cannot be used/)
+          allow(Yast::Report).to receive(:Message).with(/selected language cannot be used/)
           subject.SwitchToEnglishIfNeeded(true)
         end
 
         it "does not display any error message if not asked to do so" do
-          expect(Yast::Popup).to_not receive(:Message)
+          expect(Yast::Report).to_not receive(:Message)
           subject.SwitchToEnglishIfNeeded(false)
         end
 
@@ -300,12 +300,12 @@ describe "Language" do
         end
 
         it "displays an error message if asked to do so" do
-          expect(Yast::Popup).to receive(:Message).with(/selected language cannot be used/)
+          expect(Yast::Report).to receive(:Message).with(/selected language cannot be used/)
           subject.SwitchToEnglishIfNeeded(true)
         end
 
         it "does not display any error message if not asked to do so" do
-          expect(Yast::Popup).to_not receive(:Message)
+          expect(Yast::Report).to_not receive(:Message)
           subject.SwitchToEnglishIfNeeded(false)
         end
 

--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -258,7 +258,7 @@ describe "Language" do
       context "and it is using a non supported language" do
         let(:lang) { "ar_EG" }
 
-        it "changes the language to english" do
+        it "changes the language to English" do
           expect(subject).to receive(:WfmSetGivenLanguage).with("en_US")
           subject.SwitchToEnglishIfNeeded(true)
         end
@@ -294,7 +294,7 @@ describe "Language" do
       context "and it is using a CJK language" do
         let(:lang) { "ja_JP" }
 
-        it "changes the language to english" do
+        it "changes the language to English" do
           expect(subject).to receive(:WfmSetGivenLanguage).with("en_US")
           subject.SwitchToEnglishIfNeeded(true)
         end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 15 11:28:03 UTC 2018 - igonzalezsosa@suse.com
+
+- Fallback to english when using fbiterm on those languages
+  which are not properly supported (fate#325746).
+- 4.1.4
+
+-------------------------------------------------------------------
 Mon Nov 12 14:32:16 UTC 2018 - knut.anderssen@suse.com
 
 - Timezone: When ntp is configured to be used by default, offer

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Nov 15 11:28:03 UTC 2018 - igonzalezsosa@suse.com
 
-- Fallback to english when using fbiterm on those languages
+- Fallback to English when using fbiterm on those languages
   which are not properly supported (fate#325746).
 - 4.1.4
 

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Improve the `SwitchToEnglishIfNeeded` taking into account that some languages won't work in fbiterm. See yast/yast-installation/pull/757 for more details.