### PR TITLE
Use correct keyboard file

### DIFF
--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -452,7 +452,7 @@ return ($[
 	// keyboard layout
 	_("Lithuanian"),
 	$[
-	    "pc104"	: $[ "ncurses": "lt.baltic.map.gz"],
+	    "pc104"	: $[ "ncurses": "lt.map.gz"],
 	    "macintosh"	: $[ "ncurses": "mac-us.map.gz"],
 	    "type4"	: $[ "ncurses": "sunkeymap.map.gz"],
 	    "type5"	: $[ "ncurses": "sunkeymap.map.gz"],

--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -1416,10 +1416,10 @@ module Yast
 
     # Keyboards map
     #
-    # The map can be read from two different files:
+    # The map can be read from two different files, see {#keyboard_file}:
     #
-    # * `keyboard_raw_ID.ycp` where ID is the distribution identifier (as
-    #   specified in /etc/os-release). For example, `keyboard_raw_opensuse.ycp`.
+    # * `keyboard_raw_opensuse.ycp` when it is an opensuse distribution (according
+    #   to the distribution id specified in /etc/os-release).
     # * `keyboard_raw.ycp` as a fallback.
     #
     # @example Keyboards map format
@@ -1442,11 +1442,21 @@ module Yast
     #
     # @return [Hash] Keyboards map. See the example for content details.
     def all_keyboards
-      content = SCR.Read(path(".target.yast2"), "keyboard_raw_#{OSRelease.id}.ycp")
-      content ||= SCR.Read(path(".target.yast2"), "keyboard_raw.ycp")
+      content = SCR.Read(path(".target.yast2"), keyboard_file)
 
       # eval is necessary for translating the texts needed to be translated
       content ? Builtins.eval(content) : {}
+    end
+
+    # Keyboard file to use depending on the distribution
+    #
+    # @return [String]
+    def keyboard_file
+      if OSRelease.id.match?(/opensuse/i)
+        "keyboard_raw_opensuse.ycp"
+      else
+        "keyboard_raw.ycp"
+      end
     end
 
     # String to specify all the relevant devices in a loadkeys command

--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -26,7 +26,7 @@ module Yast
 
   describe "Keyboard" do
     let(:udev_file) { "/usr/lib/udev/rules.d/70-installation-keyboard.rules" }
-    let(:os_release_id) { "opensuse" }
+    let(:os_release_id) { "opensuse-leap" }
     let(:mode) { "normal" }
     let(:stage) { "normal" }
 
@@ -76,7 +76,7 @@ module Yast
         let(:new_lang) { "spanish" }
 
         it "writes the configuration" do
-          expect(WFM).to receive(:Execute).with(path(".local.bash_output"), 
+          expect(WFM).to receive(:Execute).with(path(".local.bash_output"),
             "/usr/bin/systemd-firstboot --root /mnt --keymap es").and_return("exit" => 0)
           expect(AsciiFile).to receive(:AppendLine).with(anything, ["Keytable:", "es.map.gz"])
 
@@ -638,7 +638,6 @@ module Yast
       let(:chroot) { "spanish" }
       let(:mode) { "normal" }
       let(:stage) { "normal" }
-      let(:os_release_id) { "sles" }
       let(:kb_model) { "macintosh" }
 
       before { allow(Yast::OSRelease).to receive(:id).and_return(os_release_id) }
@@ -650,19 +649,23 @@ module Yast
         Keyboard.kb_model = old_kb_model
       end
 
-      it "returns generic version of the keyboard map" do
-        reduced_db = Keyboard.get_reduced_keyboard_db
-        expect(reduced_db["russian"].last["ncurses"])
-          .to eq("mac-us.map.gz")
-      end
+      context "when using an opensuse product" do
+        let(:os_release_id) { "opensuse-leap" }
 
-      context "when using a product with an specific keyboard map" do
-        let(:os_release_id) { "opensuse" }
-
-        it "returns the specific version of the keyboard map" do
+        it "returns the opensuse version of the keyboard map" do
           reduced_db = Keyboard.get_reduced_keyboard_db
           expect(reduced_db["russian"].last["ncurses"])
             .to eq("us-mac.map.gz")
+        end
+      end
+
+      context "when not using an opensuse product" do
+        let(:os_release_id) { "sles" }
+
+        it "returns generic version of the keyboard map" do
+          reduced_db = Keyboard.get_reduced_keyboard_db
+          expect(reduced_db["russian"].last["ncurses"])
+            .to eq("mac-us.map.gz")
         end
       end
     end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 28 09:28:43 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Fix OS detection and use correct keyboard file for opensuse
+  (bsc#1124921).
+- Remove incompatible Lithuanian layout from opensuse file.
+- 4.1.9
+
+-------------------------------------------------------------------
 Mon Feb 18 11:36:47 UTC 2019 - snwint@suse.com
 
 - fix timezone setting when switching utc/local time (bsc#1087228)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.1.8
+Version:        4.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

There are two keyboards' "databases"

* keyboard_raw.ycp (the SLE file)
* keyboard_raw_opensuse.ycp (the openSUSE file)

And there are two problems with them

1) keyboard_raw.rb (the SLE file) contains `lt.baltic.map.gz`, which seems to be incompatible with the current consolefonts.

2) the code trusts to find opensuse as value in the ID key of /etc/os-release for openSUSE. However, what is found there is:

  * `opensuse-tumbleweed` in openSUSE TW
  * `opensuse-leap` in openSUSE Leap

Related links:

* https://bugzilla.suse.com/show_bug.cgi?id=1124921
* PBI: https://trello.com/c/xDPJ3zNM/768-2-osdistribution-p4-1124921-incorrect-keyboard-database-detection

## Solution

* Fix OS detection.
* In opensuse file, use `lt.map.gz` (as SLE file does) instead of incompatible `lt.baltic.map.gz`.

## Testing

* Adapted unit tests
* Tested manually
