### PR TITLE
Stop using obsolete XVersion

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -121,7 +121,6 @@ module Yast
       Yast.import "OSRelease"
       Yast.import "ProductFeatures"
       Yast.import "Stage"
-      Yast.import "XVersion"
       Yast.import "Report"
 
       # ------------------------------------------------------------------------
@@ -566,7 +565,7 @@ module Yast
       # do not try to run this with remote X display
       if Ops.greater_than(Builtins.size(@Apply), 0) && x11_setup_needed
         # Apply cannot be escaped as it is already set of parameters. But it is at least our string and not user provided.
-        @xkb_cmd = "#{File.join(XVersion.binPath, "setxkbmap")} #{@Apply}"
+        @xkb_cmd = "/usr/bin/setxkbmap #{@Apply}"
       else
         @xkb_cmd = ""
       end

--- a/keyboard/test/keyboard_test.rb
+++ b/keyboard/test/keyboard_test.rb
@@ -13,7 +13,6 @@ module Yast
   import "Path"
   import "Encoding"
   import "AsciiFile"
-  import "XVersion"
   import "Report"
   import "OSRelease"
   import "Keyboard"
@@ -50,7 +49,6 @@ module Yast
     describe "#Save" do
       before(:each) do
         stub_presence_of "/usr/sbin/xkbctrl"
-        allow(XVersion).to receive(:binPath).and_return "/usr/bin"
         # Stub the configuration writing...
         stub_scr_write
         # ...but allow the dump_xkbctrl helper to use SCR.Write
@@ -147,7 +145,6 @@ module Yast
 
       it "calls setxkbmap if graphical system is installed" do
         stub_presence_of "/usr/sbin/xkbctrl"
-        allow(XVersion).to receive(:binPath).and_return "/usr/bin"
 
         expect(SCR).to execute_bash(/loadkeys -C \/dev\/tty.* tr\.map\.gz/).twice
         # Called twice, for SetConsole and SetX11
@@ -187,7 +184,6 @@ module Yast
 
       before(:each) do
         stub_presence_of "/usr/sbin/xkbctrl"
-        allow(XVersion).to receive(:binPath).and_return "/usr/bin"
 
         allow(SCR).to execute_bash(/xkbctrl/) do |p, cmd|
           dump_xkbctrl(new_lang, cmd.split("> ")[1])

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug  7 08:24:31 UTC 2019 - Martin Vidner <mvidner@suse.com>
+
+- Stop using the obsolete XVersion API (gh#yast/yast-yast2#902)
+- 4.2.3
+
+-------------------------------------------------------------------
 Tue Jul 23 10:25:14 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Unify keyboard maps for openSUSE and other distributions. Now

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
It was useful in 2006 when X.org 6 and X.org 7 had different places for files