### PR TITLE
Improve some Language unit tests

### DIFF
--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -237,7 +237,7 @@ describe "Yast::Language" do
 
         it "sets the default language using systemd-firstboot" do
           expect(Yast::Execute).to receive(:locally!)
-            .with(array_including(/systemd-firstboot/, "--locale", /en_US/))
+            .with(array_including(/systemd-firstboot/, "--root", "--locale", /en_US/))
 
           subject.Save
         end
@@ -257,7 +257,7 @@ describe "Yast::Language" do
 
         it "sets the default language using systemd-firstboot" do
           expect(Yast::Execute).to receive(:locally!)
-            .with(array_including(/systemd-firstboot/, "--locale", /#{language}/))
+            .with(array_including(/systemd-firstboot/, "--root", "--locale", /#{language}/))
 
           subject.Save
         end


### PR DESCRIPTION
Ensuring that systemctl-firstboot is called with `--root`.

Related to the bug introduced in https://github.com/yast/yast-country/pull/206#pullrequestreview-215982494 and fixed in https://github.com/yast/yast-country/pull/207

---

Not version update needed.