### PR TITLE
Fix opensuse keymaps

### DIFF
--- a/keyboard/src/data/keyboard_raw_opensuse.ycp
+++ b/keyboard/src/data/keyboard_raw_opensuse.ycp
@@ -93,8 +93,8 @@ return ($[
 	    "pc104"	: $[ "ncurses": "ch-de_nodeadkeys.map.gz" ],
 	    "macintosh" : $[ "ncurses": "ch-de_mac.map.gz" ],
 	    "type4"	: $[ "ncurses": "us.map.gz" ],
-	    "type5"	: $[ "ncurses": "ch-de-sundeadkeys.map.gz" ],
-	    "type5_euro": $[ "ncurses": "ch-de-sundeadkeys.map.gz" ],
+	    "type5"	: $[ "ncurses": "ch-de_sundeadkeys.map.gz" ],
+	    "type5_euro": $[ "ncurses": "ch-de_sundeadkeys.map.gz" ],
 	]
     ],
   "french":
@@ -117,8 +117,8 @@ return ($[
 	    "pc104"	: $[ "ncurses": "ch-fr.map.gz"],
 	    "macintosh" : $[ "ncurses": "ch-fr_mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
-	    "type5"	: $[ "ncurses": "ch-fr-sundeadkeys.map.gz" ],
-	    "type5_euro": $[ "ncurses": "ch-fr-sundeadkeys.map.gz" ],
+	    "type5"	: $[ "ncurses": "ch-fr_sundeadkeys.map.gz" ],
+	    "type5_euro": $[ "ncurses": "ch-fr_sundeadkeys.map.gz" ],
 	]
     ],
   "french-ca":
@@ -299,7 +299,7 @@ return ($[
 	    "pc104"	: $[ "ncurses": "se.map.gz"],
 	    "macintosh" : $[ "ncurses": "se-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
-	    "type5"	: $[ "ncurses": "us1.map.gz" ],
+	    "type5"	: $[ "ncurses": "us.map.gz" ],
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],
 	]
     ],
@@ -311,7 +311,7 @@ return ($[
             "pc104"     : $[ "ncurses": "fi-kotoistus.map.gz"],
 	    "macintosh" : $[ "ncurses": "fi-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
-	    "type5"	: $[ "ncurses": "us1.map.gz" ],
+	    "type5"	: $[ "ncurses": "us.map.gz" ],
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],
 	]
     ],
@@ -535,7 +535,8 @@ return ($[
 	// keyboard layout
 	_("Khmer"),
 	$[
-	    "pc104"	: $[ "ncurses"	: "khmer.map.gz" ],
+	    // This used to be khmer.map.gz, but that is only a link to us.map.gz
+	    "pc104"	: $[ "ncurses"	: "us.map.gz" ],
 	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
 	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
@@ -559,7 +560,8 @@ return ($[
 	// keyboard layout
 	_("Arabic"),
 	$[
-	    "pc104"	: $[ "ncurses"	: "arabic.map.gz" ],
+	    // This used to be arabic.map.gz, but that is only a link to us.map.gz
+	    "pc104"	: $[ "ncurses"	: "us.map.gz" ],
 	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
 	    "type5"	: $[ "ncurses"	: "us.map.gz" ],

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 22 14:09:42 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed some wrong keyboard maps (follow-up of bsc#1124921)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:28:08 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
This is a previous step for unifying SLE and openSUSE keymaps to use the ones from `keyboard_raw_opensuse.ycp`. While checking the current status we found some errors in the openSUSE file and I would like to fix them first (with its own version and so on) before performing the unification.

To get the full picture, read [bsc#1124921](https://bugzilla.suse.com/show_bug.cgi?id=1124921) starting at comment 18 (the previous comments refer to issues fixed a long time ago).

Part of https://trello.com/c/vYVMPFWZ/971-follow-up-of-1124921-try-to-merge-keyboardrawopensuseycp and also partially related to https://trello.com/c/znCthGFV/1142-5-sle15-sp1-p2-1140872-sles15-sp1-systemd-vconsole-setupservice-failed