### PR TITLE
 Add missing Persian/Farsi language and keyboard layout

### DIFF
--- a/README
+++ b/README
@@ -1,2 +1,0 @@
-Country specific data and configuration modules (language, keyboard,
-timezone) for YaST2.

--- a/README.markdown
+++ b/README.markdown
@@ -20,3 +20,130 @@ timezone) for YaST2.
 ## Links ##
 
   * See more at http://en.opensuse.org/openSUSE:YaST_development
+
+## Adding a New Country
+
+- console/src/data/consolefonts.json
+
+    - key: locale_id
+    - font: /usr/share/kbd/consolefonts/%s.gz (kbd.rpm)
+    - unicodeMap: ?
+    - screenMap: ?
+    - magic: ?
+
+    ---
+
+    ```json
+    "en_GB": {
+        "font": "eurlatgr.psfu",
+        "unicodeMap": "",
+        "screenMap": "",
+        "magic": ""
+    }
+    ```
+
+    ---
+
+- keyboard/src/data/keyboard_raw.ycp
+
+    Console keyboard layout
+
+    - key: yast_keyboard_id
+    - value: pair of translatable_string, more_data:
+        - key: keyboard_hardware (pc104, macintosh, type4, type5, type5_euro)
+        - value: more_data:
+            - ncurses: /usr/share/kbd/keymaps/xkb/%s
+            - compose: ? (optional)
+
+    ---
+
+    ```js
+    "english-uk": [
+        _("English (UK)"),
+        $[
+            "pc104":      $[ "ncurses": "gb.map.gz"],
+            "macintosh":  $[ "ncurses": "gb-mac.map.gz" ],
+            "type4":      $[ "ncurses": "us.map.gz"],
+            "type5":      $[ "ncurses": "us.map.gz"],
+            "type5_euro": $[ "ncurses": "us.map.gz"],
+        ]
+    ]
+
+    ```
+
+    ---
+
+- keyboard/src/data/lang2keyboard.ycp (TODO convert)
+    - key: locale_id
+    - value: yast_keyboard_id
+
+    ---
+
+    ```js
+    "en_GB": "english-uk"
+    ```
+
+    ---
+
+- keyboard/src/data/xkblayout2keyboard.ycp (TODO convert)
+
+    man xkeyboard-config
+
+    - key: xkblayout_id ?
+    - value: yast_keyboard_id
+
+    ---
+
+    ```js
+    "gb": "english-uk"
+    ```
+
+    ---
+
+- language/src/data/languages/language_%s.ycp (ll_TT)
+    - ll_TT: 5-tuple
+        - (native) name in unicode
+        - (native) name in ascii
+        - utf-8 modifier
+        - non-utf-8 modifier
+        - translatable name
+    - timezone: tz_id
+    - keyboard: yast_keyboard_id
+
+    ---
+
+    ```js
+    $[
+        "en_GB"	: [
+            "English (UK)",
+            "English (UK)",
+            ".UTF-8",
+            "",
+            _("English (UK)")
+        ],
+        "timezone"	: "Europe/London",
+        "keyboard"	: "english-uk",
+    ]
+    ```
+
+    ---
+
+- timezone/src/data/lang2tz.ycp
+
+    > NOTE: it is also in language_xx_XX.ycp
+
+    - key: locale_id
+    - value: tz_id
+
+    ---
+
+    ```js
+    "en_GB": "Europe/London"
+    ```
+
+    ---
+
+- timezone/src/data/timezone_raw.ycp
+
+    Translatable TZ names (timezone_db.pot)
+

--- a/console/src/data/consolefonts.json
+++ b/console/src/data/consolefonts.json
@@ -71,6 +71,12 @@
     "screenMap": "",
     "magic": ""
   },
+  "fa_IR": {
+    "font": "latarcyrheb-sun16.psfu",
+    "unicodeMap": "",
+    "screenMap": "",
+    "magic": ""
+  },
   "fr": {
     "font": "eurlatgr.psfu",
     "unicodeMap": "",

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -199,6 +199,25 @@ return ($[
 	    "type5_euro": $[ "ncurses": "us.map.gz" ],
 	]
     ],
+  "persian":
+    [
+	// keyboard layout
+	//
+	// NOTE: "ir-ku" is a Kurdish keyboard map, with Latin letters. The kbd.rpm
+	// package also has a "ir-ku_ara" keymap which uses Arabic letters, but in a
+	// QWERTY layout. Neither corresponds to the ISRI 9147 standard for a
+	// Persian keyboard (see page 29 of the
+	// http://persian-computing.org/archives/ISIRI/ISIRI-9147.pdf
+	// document) but we don't have a better thing now.
+	_("Persian"),
+	$[
+	    "pc104"	: $[ "ncurses": "ir-ku.map.gz"],
+	    "macintosh" : $[ "ncurses": "ir-ku.map.gz"],
+	    "type4"	: $[ "ncurses": "ir-ku.map.gz" ],
+	    "type5"	: $[ "ncurses": "ir-ku.map.gz" ],
+	    "type5_euro": $[ "ncurses": "ir-ku.map.gz" ],
+	]
+    ],
   "portugese":
     [
 	// keyboard layout

--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -202,20 +202,13 @@ return ($[
   "persian":
     [
 	// keyboard layout
-	//
-	// NOTE: "ir-ku" is a Kurdish keyboard map, with Latin letters. The kbd.rpm
-	// package also has a "ir-ku_ara" keymap which uses Arabic letters, but in a
-	// QWERTY layout. Neither corresponds to the ISRI 9147 standard for a
-	// Persian keyboard (see page 29 of the
-	// http://persian-computing.org/archives/ISIRI/ISIRI-9147.pdf
-	// document) but we don't have a better thing now.
 	_("Persian"),
 	$[
-	    "pc104"	: $[ "ncurses": "ir-ku.map.gz"],
-	    "macintosh" : $[ "ncurses": "ir-ku.map.gz"],
-	    "type4"	: $[ "ncurses": "ir-ku.map.gz" ],
-	    "type5"	: $[ "ncurses": "ir-ku.map.gz" ],
-	    "type5_euro": $[ "ncurses": "ir-ku.map.gz" ],
+	    "pc104"	: $[ "ncurses": "ir.map.gz"],
+	    "macintosh" : $[ "ncurses": "ir.map.gz"],
+	    "type4"	: $[ "ncurses": "ir.map.gz" ],
+	    "type5"	: $[ "ncurses": "ir.map.gz" ],
+	    "type5_euro": $[ "ncurses": "ir.map.gz" ],
 	]
     ],
   "portugese":

--- a/keyboard/src/data/lang2keyboard.ycp
+++ b/keyboard/src/data/lang2keyboard.ycp
@@ -40,6 +40,8 @@
 
 	"es"		: "spanish",
 
+	"fa_IR"		: "persian",
+
 	"fr"		: "french",
 	"fr_BE"		: "french",
 	"fr_CA"		: "cn-latin1",

--- a/keyboard/src/data/xkblayout2keyboard.ycp
+++ b/keyboard/src/data/xkblayout2keyboard.ycp
@@ -79,5 +79,5 @@ $[
 	"hr"		: "croatian",
 	"ua"		: "ukrainian",
 	"kr"		: "korean",
-	"ir_ku"		: "persian",
+	"ir"		: "persian",
 ]

--- a/keyboard/src/data/xkblayout2keyboard.ycp
+++ b/keyboard/src/data/xkblayout2keyboard.ycp
@@ -79,4 +79,5 @@ $[
 	"hr"		: "croatian",
 	"ua"		: "ukrainian",
 	"kr"		: "korean",
+	"ir_ku"		: "persian",
 ]

--- a/language/src/Makefile.am
+++ b/language/src/Makefile.am
@@ -8,13 +8,13 @@ module1_DATA = \
   modules/YaPI/LANGUAGE.pm
 
 client_DATA = \
-  clients/language_proposal.rb \
-  clients/language.rb \
-  clients/language_auto.rb \
   clients/country_simple_proposal.rb \
   clients/inst_language.rb \
-  clients/select_language.rb \
-  clients/language_simple_proposal.rb
+  clients/language.rb \
+  clients/language_auto.rb \
+  clients/language_proposal.rb \
+  clients/language_simple_proposal.rb \
+  clients/select_language.rb
 
 scrconf_DATA = \
   scrconf/sysconfig_language.scr
@@ -25,65 +25,65 @@ schemafiles_DATA = \
 
 ydatadir = @ydatadir@/languages
 ydata_DATA = \
-  data/languages/language_pt_PT.ycp \
-  data/languages/language_es_ES.ycp \
-  data/languages/language_zu_ZA.ycp \
-  data/languages/language_sr_RS.ycp \
-  data/languages/language_fr_FR.ycp \
-  data/languages/language_bn_BD.ycp \
-  data/languages/language_da_DK.ycp \
-  data/languages/language_lt_LT.ycp \
-  data/languages/languages.ycp \
-  data/languages/language_nn_NO.ycp \
-  data/languages/language_nl_NL.ycp \
-  data/languages/language_ja_JP.ycp \
-  data/languages/language_km_KH.ycp \
-  data/languages/language_hr_HR.ycp \
-  data/languages/language_gl_ES.ycp \
-  data/languages/language_pl_PL.ycp \
-  data/languages/language_hu_HU.ycp \
-  data/languages/language_et_EE.ycp \
-  data/languages/language_mr_IN.ycp \
-  data/languages/language_gu_IN.ycp \
-  data/languages/language_hi_IN.ycp \
-  data/languages/language_id_ID.ycp \
-  data/languages/language_uk_UA.ycp \
-  data/languages/language_sk_SK.ycp \
-  data/languages/language_tr_TR.ycp \
-  data/languages/language_bg_BG.ycp \
-  data/languages/language_el_GR.ycp \
-  data/languages/language_it_IT.ycp \
-  data/languages/language_zh_CN.ycp \
-  data/languages/language_ca_ES.ycp \
-  data/languages/language_ar_EG.ycp \
-  data/languages/language_ro_RO.ycp \
-  data/languages/language_sl_SI.ycp \
-  data/languages/language_wa_BE.ycp \
-  data/languages/language_ta_IN.ycp \
-  data/languages/language_fi_FI.ycp \
-  data/languages/language_vi_VN.ycp \
-  data/languages/language_tg_TJ.ycp \
-  data/languages/language_ru_RU.ycp \
-  data/languages/language_ko_KR.ycp \
-  data/languages/language_nb_NO.ycp \
-  data/languages/language_cy_GB.ycp \
-  data/languages/language_he_IL.ycp \
-  data/languages/language_bs_BA.ycp \
-  data/languages/language_en_US.ycp \
-  data/languages/language_ast_ES.ycp \
-  data/languages/language_cs_CZ.ycp \
-  data/languages/language_pa_IN.ycp \
-  data/languages/language_pt_BR.ycp \
-  data/languages/language_de_DE.ycp \
-  data/languages/language_si_LK.ycp \
-  data/languages/language_zh_TW.ycp \
   data/languages/language_af_ZA.ycp \
-  data/languages/language_xh_ZA.ycp \
-  data/languages/language_sv_SE.ycp \
-  data/languages/language_mk_MK.ycp \
+  data/languages/language_ar_EG.ycp \
+  data/languages/language_ast_ES.ycp \
+  data/languages/language_bg_BG.ycp \
+  data/languages/language_bn_BD.ycp \
+  data/languages/language_bs_BA.ycp \
+  data/languages/language_ca_ES.ycp \
+  data/languages/language_cs_CZ.ycp \
+  data/languages/language_cy_GB.ycp \
+  data/languages/language_da_DK.ycp \
+  data/languages/language_de_DE.ycp \
+  data/languages/language_el_GR.ycp \
+  data/languages/language_en_GB.ycp \
+  data/languages/language_en_US.ycp \
+  data/languages/language_es_ES.ycp \
+  data/languages/language_et_EE.ycp \
+  data/languages/language_fi_FI.ycp \
+  data/languages/language_fr_FR.ycp \
+  data/languages/language_gl_ES.ycp \
+  data/languages/language_gu_IN.ycp \
+  data/languages/language_he_IL.ycp \
+  data/languages/language_hi_IN.ycp \
+  data/languages/language_hr_HR.ycp \
+  data/languages/language_hu_HU.ycp \
+  data/languages/language_id_ID.ycp \
+  data/languages/language_it_IT.ycp \
+  data/languages/language_ja_JP.ycp \
   data/languages/language_ka_GE.ycp \
+  data/languages/language_km_KH.ycp \
+  data/languages/language_ko_KR.ycp \
+  data/languages/language_lt_LT.ycp \
+  data/languages/language_mk_MK.ycp \
+  data/languages/language_mr_IN.ycp \
+  data/languages/language_nb_NO.ycp \
+  data/languages/language_nl_NL.ycp \
+  data/languages/language_nn_NO.ycp \
+  data/languages/language_pa_IN.ycp \
+  data/languages/language_pl_PL.ycp \
+  data/languages/language_pt_BR.ycp \
+  data/languages/language_pt_PT.ycp \
+  data/languages/language_ro_RO.ycp \
+  data/languages/language_ru_RU.ycp \
+  data/languages/language_si_LK.ycp \
+  data/languages/language_sk_SK.ycp \
+  data/languages/language_sl_SI.ycp \
+  data/languages/language_sr_RS.ycp \
+  data/languages/language_sv_SE.ycp \
+  data/languages/language_ta_IN.ycp \
+  data/languages/language_tg_TJ.ycp \
   data/languages/language_th_TH.ycp \
-  data/languages/language_en_GB.ycp
+  data/languages/language_tr_TR.ycp \
+  data/languages/language_uk_UA.ycp \
+  data/languages/language_vi_VN.ycp \
+  data/languages/language_wa_BE.ycp \
+  data/languages/language_xh_ZA.ycp \
+  data/languages/language_zh_CN.ycp \
+  data/languages/language_zh_TW.ycp \
+  data/languages/language_zu_ZA.ycp \
+  data/languages/languages.ycp
 
 ylibdir = @ylibdir@/y2country
 ylib_DATA = \

--- a/language/src/Makefile.am
+++ b/language/src/Makefile.am
@@ -41,6 +41,7 @@ ydata_DATA = \
   data/languages/language_en_US.ycp \
   data/languages/language_es_ES.ycp \
   data/languages/language_et_EE.ycp \
+  data/languages/language_fa_IR.ycp \
   data/languages/language_fi_FI.ycp \
   data/languages/language_fr_FR.ycp \
   data/languages/language_gl_ES.ycp \

--- a/language/src/data/languages/language_fa_IR.ycp
+++ b/language/src/data/languages/language_fa_IR.ycp
@@ -1,0 +1,40 @@
+/**
+ * This file contains the description of the language needed by yast2-country
+ * module.
+ *
+ * Translation of the "language name" to actual YaST language be must applied
+ * each time this file is invoked.
+ *
+ * If you want to add new language to YaST using a file of this type provided
+ * by some module different from yast2-country (e.g. in some Add-On Product),
+ * consider using special textdomain, so it is possible to provide also
+ * translations of the 'language name' string to all installed languages.
+ */
+{
+    textdomain "languages_db";
+
+    return
+    $[
+	// 1. information for language selection:
+	// Format is
+	// <LANG-Code> : [
+	//	<Language-to-display-UTF8-coded>,
+	//	<Language-to-display-ASCII-coded-if-needed>,
+	//	<LANG modifier used when UTF-8 enconding is selected>
+	//	<LANG modifier used when no UTF-8 enconding is selected>
+	//	<translated Language-to-display-UTF8-coded> ]
+	//
+	"fa_IR"	: [
+		    "فارسی",
+		    "Persian",
+		    ".UTF-8",
+		    "",
+		    // language name
+		    _("Persian")
+	],
+	// 2. what time zone propose for this language
+	"timezone"	: "Asia/Tehran",
+	// 3. which keyboard layout propose for this language
+	"keyboard"	: "persian",
+    ];
+}

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 18 08:52:48 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Add missing Persian/Farsi language and keyboard layout
+  (bsc#1092920).
+- 4.2.5
+
+-------------------------------------------------------------------
 Wed Aug 14 15:15:05 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Restore some needed keyboard maps (follow-up of bsc#1124921).

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/data/lang2tz.ycp
+++ b/timezone/src/data/lang2tz.ycp
@@ -47,6 +47,8 @@ $[
   "es_UY"		: "America/Montevideo",
   "es_VE"		: "America/Caracas",
 
+  "fa_IR"		: "Asia/Tehran",
+
   "fr"			: "Europe/Paris",
   "fr_BE"		: "Europe/Brussels",
   "fr_CA"		: "Canada/Eastern",


### PR DESCRIPTION
## Problem

There is a high amount of translated [Persian (fa) strings in Weblate](https://l10n.opensuse.org/languages/fa/) but there is not a way to select it in YaST.

* https://bugzilla.suse.com/show_bug.cgi?id=1092920
* https://trello.com/c/JN3jZ3Bw/1138-os-p4-1092920-missing-persianfarsi-in-language-and-keyboard-selection

(Naming: "Farsi" is the native name, or endonym,  for the language, "Persian" is the English term. Compare "Español" vs "Spanish".)

## Solution

We simply add Persian to the list of supported languages, right?

Yes, except it also means picking
- a default time zone (`Asia/Tehran`, easy),
- the X11 keyboard layout (`ir`, easy)
- and the console keyboard layout (er, um, oh my god, unsee, uns̪̫ͅe̻̦͓͑̏̐è̹,͔̼̏̽͛ͅ ̌̇ẃ̺̰̑h͈̲ăt̻̳ͦ͐ ͕͖̈́̑i͔̺s ͇̞̮t̖̫̻h̩̝̅ͪis,͔̱̥̏̽ͮ ̫̤ͬ͐̆ͅĬ͔̯̟̏̚ ̹̯̥̌̔̆wa̗͔͊̌nṱ͕̫ͣ͗͗ t̫͌o ̫̪̓̊̈ͅge̻ͮt ͬ̓out̓)

Long story short, the console uses the US keyboard layout, and two changes to Base:System packages are needed:
-    https://build.opensuse.org/request/show/731897 (systemd)
-    https://build.opensuse.org/request/show/731900 (kbd)

## Testing
- [x] switching the keyboard with `yast2 keyboard` in an installed system
- [x] installing in Persian: many strings are missing

### Testing Hints

Or, "How to Pretend You Have a Clue Even If You Can't Speak or Read Persian"

Persian uses the Arabic script. The Iranian keyboard layout ([ISIRI 9147](https://en.wikipedia.org/wiki/ISIRI_9147)) can be distinguished from other Arabic-typing layouts by producing the letter پ ![persian-letter-pe](https://user-images.githubusercontent.com/102056/65242852-63e89c00-dae7-11e9-9a67-c8cd07eb3383.png) on the Latin <kbd>M</kbd> key. It changes shape if you type more than one. The 3 dots below are what matters.

## Screenshots

Below screenshots taken in an openSUSE Tumbleweed (`VERSION_ID="20190630"`) using KDE

<details>
<summary>Click to show/hide them</summary>

<p align="center"><sub><em>YaST Language</em></sub></p>

![language](https://user-images.githubusercontent.com/1691872/61780373-4dc9a280-adfa-11e9-8b0e-2fb6f5db29fc.png)

---

<p align="center"><sub><em>YaST Partitioner</em></sub></p>

![partitioner](https://user-images.githubusercontent.com/1691872/61780374-4dc9a280-adfa-11e9-8c74-3b47b1beb84b.png)

---

<p align="center"><sub><em>System Preferences</em></sub></p>

![kde_settings](https://user-images.githubusercontent.com/1691872/61780376-4e623900-adfa-11e9-8508-35ee1912b753.png)

---


<p align="center"><sub><em>Mozilla Firefox</em></sub></p>

![firefox](https://user-images.githubusercontent.com/1691872/61780377-4e623900-adfa-11e9-8d58-c64294d73861.png)

</details>

## Implementation Details and Further Work

(Original incomplete PR for reference: #211)

6 data files in this repo had to be changed for this, out of which 3 relate to
keyboard layout, which also needed 2 more in other packages (kbd.rpm and
systemd.rpm, while the resulting file is massaged by yast2-x11.rpm). Pretty
crazy.

We should consider using some common database (presumably maintained together
with other Linux distros). Ludwig Nussel [has suggested](https://bugzilla.suse.com/show_bug.cgi?id=1092920#c7):

> https://github.com/mike-fabian/langtable This database actually looks
awesome. Given the maintainer it's no surprise. I guess it would make sense
for YaST to move over to that database mid term instead of keeping our own.

See also "Refactoring Keyboard" (#225 + https://github.com/openSUSE/mentoring/issues/79)