### PR TITLE
Restore some keymaps

### DIFF
--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -527,8 +527,9 @@ return ($[
 	// keyboard layout
 	_("Khmer"),
 	$[
-	    // This used to be khmer.map.gz, but that is only a link to us.map.gz
-	    "pc104"	: $[ "ncurses"	: "us.map.gz" ],
+        // Although khmer.map.gz is only a link to us.map.gz, it's important to keep the
+        // khmer name because is used by yast2-x11 to to obtain the proper XkbLayout
+	    "pc104"	: $[ "ncurses"	: "khmer.map.gz" ],
 	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
 	    "type5"	: $[ "ncurses"	: "us.map.gz" ],
@@ -552,8 +553,9 @@ return ($[
 	// keyboard layout
 	_("Arabic"),
 	$[
-	    // This used to be arabic.map.gz, but that is only a link to us.map.gz
-	    "pc104"	: $[ "ncurses"	: "us.map.gz" ],
+        // Although arabic.map.gz is only a link to us.map.gz, it's important to keep the
+        // arabic name because is used by yast2-x11 to to obtain the proper XkbLayout
+	    "pc104"	: $[ "ncurses"	: "arabic.map.gz" ],
 	    "macintosh" : $[ "ncurses"	: "us-mac.map.gz" ],
 	    "type4"	: $[ "ncurses"	: "us.map.gz" ],
 	    "type5"	: $[ "ncurses"	: "us.map.gz" ],

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 14 15:15:05 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Restore some needed keyboard maps (follow-up of bsc#1124921).
+- 4.2.4
+
+-------------------------------------------------------------------
 Wed Aug  7 08:24:31 UTC 2019 - Martin Vidner <mvidner@suse.com>
 
 - Stop using the obsolete XVersion API (gh#yast/yast-yast2#902)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

After the [keymaps fixes](https://github.com/yast/yast-country/pull/218), the _arabic_ and _khmer_ keymaps stop working in X11.

## Why?

Since 

> Although actually they are only symlinks to `us.map.gz`, are still being
needed because the yast2-x11 is using them to obtain the proper
"XkbLayout".

<details>
<summary>Click to show/hide a _rather long_ explanation</summary>

---

*Information extracted from https://trello.com/c/y5fA3MK2*

While looking for a keyboard layout for Farsi language, I found that we could have a problem with the latest changes introduced by @ancorgs  when unifying the `keyboard_raw.ycp` and `keyboard_raw_opensuse.ycp` files.

The _arabic.map.gz_ and _khmer.map.gz_ were changed into _us.map.gz_ since former are simply links to the latest. However, the change has a not desired/expected side effect: the keyboard layout isn't being changed properly in X11. Why? Because of _yast2-x11_, more exactly the [`xkbctrl`](https://github.com/yast/yast-x11/blob/master/src/tools/xkbctrl) tool, which is being used by the keyboard module to "get the keyboard info for X11" based on the given keymap.

* https://github.com/yast/yast-country/blob/4fb3fe62b42778609d28f8f92b02eed2c3d88e67/keyboard/src/modules/Keyboard.rb#L543
* https://github.com/yast/yast-country/blob/4fb3fe62b42778609d28f8f92b02eed2c3d88e67/keyboard/src/modules/Keyboard.rb#L382

As could be seen following the links above, it will end executing 

> /usr/sbin/xkbctrl <keymap>

which will produce different outputs for _arabic.map.gz_, _khmer.map.gz_, and _us.map.gz_. See below.

```
❯ /usr/sbin/xkbctrl arabic.map.gz
$[
   "XkbLayout"    : "ara,us",
   "XkbModel"     : "pc105",
   "XkbOptions"   : "terminate:ctrl_alt_bksp,grp:shift_toggle",
   "Apply"        : "-layout ara,us -model pc105 -option terminate:ctrl_alt_bksp,grp:shift_toggle"
]
```

```
❯ /usr/sbin/xkbctrl khmer.map.gz
$[
   "XkbLayout"    : "kh,us",
   "XkbModel"     : "pc105",
   "XkbOptions"   : "terminate:ctrl_alt_bksp",
   "Apply"        : "-layout kh,us -model pc105 -option terminate:ctrl_alt_bksp"
]
```

```
❯ /usr/sbin/xkbctrl us.map.gz
$[
   "XkbLayout"    : "us",
   "XkbModel"     : "microsoftpro",
   "XkbOptions"   : "terminate:ctrl_alt_bksp",
   "Apply"        : "-layout us -model microsoftpro -option terminate:ctrl_alt_bksp"
]
```

Then, the value of `Apply` part is being used at 

https://github.com/yast/yast-country/blob/4fb3fe62b42778609d28f8f92b02eed2c3d88e67/keyboard/src/modules/Keyboard.rb#L569

> setxkbmap -layout ara,us -model pc105 -option terminate:ctrl_alt_bksp,grp:shift_toggle

and the rest of data in [`write_udev_rule`](https://github.com/yast/yast-country/blob/4fb3fe62b42778609d28f8f92b02eed2c3d88e67/keyboard/src/modules/Keyboard.rb#L1374), which seems to set the X11 keyboard [during the installation](https://github.com/yast/yast-country/blob/4fb3fe62b42778609d28f8f92b02eed2c3d88e67/keyboard/src/modules/Keyboard.rb#L1041) 

I did a handful of tests and I can confirm that the "original" behavior is broken in both, SLE and openSUSE, when using Gnome Classic/X11, but not in Gnome Wayland, where the keyboard layout never changes .
</details>


## Solution

Restore the `arabic.map.gz` and `khmer.map.gz` keymaps.

## Tests

* Tested manually via dud.

## Screenshots

<details>
<summary>Click to show/hide some screenshots</summary>

![Screenshot_sle15sp2_2019-08-14_16:52:37](https://user-images.githubusercontent.com/1691872/63148768-16fe3b00-bffa-11e9-9a14-4888b45080e2.png)

<p align="center"><sub>During installation</sub></p>

---

![Screenshot_sle15sp2_2019-08-16_07:46:01](https://user-images.githubusercontent.com/1691872/63148815-41e88f00-bffa-11e9-865c-210c38e0f868.png)

<p align="center"><sub>In an installed system</sub></p>

</details>

---

Related to https://github.com/yast/yast-country/pull/218
