### PR TITLE
Restore the SCR agent for /etc/vconsole.conf

### DIFF
--- a/console/src/Makefile.am
+++ b/console/src/Makefile.am
@@ -4,7 +4,8 @@ module_DATA = \
   modules/Console.rb
 
 scrconf_DATA = \
-  scrconf/sysconfig_console.scr
+  scrconf/sysconfig_console.scr \
+  scrconf/etc_vconsole_conf.scr
 
 ydata_DATA = \
   data/consolefonts.json

--- a/console/src/scrconf/etc_vconsole_conf.scr
+++ b/console/src/scrconf/etc_vconsole_conf.scr
@@ -1,0 +1,13 @@
+.etc.vconsole_conf
+
+`ag_ini(
+    `IniAgent( "/etc/vconsole.conf",
+	$[
+	    "options" : [ "global_values", "flat" ],
+	    "comments" : [ "^#.*", "^[ \t]*$", ],
+	    "params" : [
+                $[ "match" : [ "^[ \t]*([^=]*[^ \t=])[ \t]*=[ \t]*(.*[^ \t]|)[ \t]*$" , "%s=%s"] ]
+	    ]
+	]
+    )
+)

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 28 22:42:34 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Bring back the agent to set the console font, deleted during the
+  keyboard module refactorization (bsc#1156896).
+- 4.2.8
+
+-------------------------------------------------------------------
 Thu Oct 19 13:31:45 CEST 2019 - schubi@suse.de
 
 - Refactoring complete keyboard workflow.

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

After the keyboard module refactorization (#225, https://github.com/openSUSE/mentoring/issues/79), the console font is not being set due to the deletion of the _etc_vconsole_conf_ SCR agent, which [still in use by the **console** module](https://github.com/yast/yast-country/blob/4e32e3a3ab319240f752a3158fb5e6f3ed4dc291/console/src/modules/Console.rb#L135-L139).

- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1156896
- Trello card: https://trello.com/c/CvIQtD0Z

## Solution

To restore the agent, but placing it in the **console** module.

## Tests

Tested manually.

## Screenshots

| Before | After |
|--|--|
| ![before](https://user-images.githubusercontent.com/1691872/69837359-3d14b780-1246-11ea-97cc-47cbbd387bbc.png) | ![after](https://user-images.githubusercontent.com/1691872/69837365-42720200-1246-11ea-99cf-2fafdce2a42d.png) |


## Notes

The keyboard module now relies in [systemd](https://freedesktop.org/wiki/Software/systemd/) for the keyboard configuration and there is a [systemd-vconsole-setup](http://man7.org/linux/man-pages/man8/systemd-vconsole-setup.service.8.html) helper to configure the virtual consoles. However, the [systemd-firstboot](http://man7.org/linux/man-pages/man1/systemd-firstboot.1.html), used during the installation, only [has support for the keymap](https://github.com/systemd/systemd/pull/7035).


---

FYI, the agent was originally introduced in #30, more specifically in cd0e0da.