### PR TITLE
Master 1158119

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -116,6 +116,15 @@ module Yast
       @modified = true
     end
 
+    # Reset all setting
+    def reset
+      @curr_kbd = ""
+      @keyboard_on_entry = ""
+      @default_kbd = ""
+      @user_decision = false
+      @modified = false
+    end
+
     # Set current data into the installed system.
     def Save
       if Mode.update
@@ -176,8 +185,9 @@ module Yast
         # Only follow the language if the user has never actively chosen
         # a keyboard. The indicator for this is user_decision which is
         # set from outside the module.
-        if @user_decision || Mode.update && !Stage.initial || Mode.auto ||
+        if @user_decision || Mode.update && !Stage.initial ||
             Mode.live_installation ||
+            (Mode.auto && !@curr_kbd.empty?) || # AY has already set keyboard
             ProductFeatures.GetStringFeature("globals", "keyboard") != ""
           if language_changed
             log.info(
@@ -316,6 +326,7 @@ module Yast
     publish :function => :Modified, :type => "boolean ()"
     publish :function => :SetModified, :type => "void (boolean)"
     publish :function => :Save, :type => "void ()"
+    publish :function => :reset, :type => "void ()"
     publish :function => :MakeProposal, :type => "string (boolean, boolean)"
     publish :function => :Selection, :type => "map <string, string> ()"
     publish :function => :codes, type: "map <string,string> ()"

--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -116,15 +116,6 @@ module Yast
       @modified = true
     end
 
-    # Reset all setting
-    def reset
-      @curr_kbd = ""
-      @keyboard_on_entry = ""
-      @default_kbd = ""
-      @user_decision = false
-      @modified = false
-    end
-
     # Set current data into the installed system.
     def Save
       if Mode.update
@@ -326,7 +317,6 @@ module Yast
     publish :function => :Modified, :type => "boolean ()"
     publish :function => :SetModified, :type => "void (boolean)"
     publish :function => :Save, :type => "void ()"
-    publish :function => :reset, :type => "void ()"
     publish :function => :MakeProposal, :type => "string (boolean, boolean)"
     publish :function => :Selection, :type => "map <string, string> ()"
     publish :function => :codes, type: "map <string,string> ()"

--- a/keyboard/test/keyboard_spec.rb
+++ b/keyboard/test/keyboard_spec.rb
@@ -138,11 +138,12 @@ describe "Yast::Keyboard" do
       end
 
       context "AutoYaST has not defined a keyboard" do
+        subject { Yast::KeyboardClass.new }
         before do
           allow(Yast::Mode).to receive(:auto).and_return true
         end
         it "makes a proposal" do
-          subject.reset
+          subject.main()
           expect(subject).to receive(:Set)
           subject.MakeProposal(false, false)
         end

--- a/keyboard/test/keyboard_spec.rb
+++ b/keyboard/test/keyboard_spec.rb
@@ -136,6 +136,17 @@ describe "Yast::Keyboard" do
           subject.MakeProposal(false, false)
         end
       end
+
+      context "AutoYaST has not defined a keyboard" do
+        before do
+          allow(Yast::Mode).to receive(:auto).and_return true
+        end
+        it "makes a proposal" do
+          subject.reset
+          expect(subject).to receive(:Set)
+          subject.MakeProposal(false, false)
+        end
+      end
     end
   end
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  2 11:11:17 CET 2019 - schubi@suse.de
+
+- AutoYaST keyboard: Do not crash if no language and keyboard
+  sections have been defined (bsc#1158119).
+- 4.2.8
+
+-------------------------------------------------------------------
 Thu Oct 19 13:31:45 CEST 2019 - schubi@suse.de
 
 - Refactoring complete keyboard workflow.

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Keyboard has to be set in the proposal if AutoYaST has not already set it.

* Fast-track: https://trello.com/c/sL8vbVZI/1465-https-bugzillasusecom-showbugcgiid1158119

* This one is blocking Staging:Y from being accepted.

* https://openqa.suse.de/tests/3646052#step/installation/4

## Solution

Avoid to crash when no language and keyboard is defined.
