### PR TITLE
Improve Windows detection

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  4 13:26:52 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Improve detection of Windows system (related to bsc#1135341).
+- 4.2.10
+
+-------------------------------------------------------------------
 Mon Dec  2 11:11:17 CET 2019 - schubi@suse.de
 
 - AutoYaST keyboard: Do not crash if no language and keyboard

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -1036,16 +1036,13 @@ module Yast
 
     # Checks whether the system has Windows installed
     def system_has_windows?
-      begin
-        win_partitions = disk_analyzer.windows_partitions
-        !win_partitions.empty?
-      rescue NameError => ex
-        # bsc#1058869: Don't enforce y2storage being available
-        log.warn("Caught #{ex}")
-        log.warn("No storage-ng support - not checking for a windows partition")
-        log.warn("Assuming UTC for the hardware clock")
-        false # No windows partition found
-      end
+      disk_analyzer.windows_system?
+    rescue NameError => ex
+      # bsc#1058869: Don't enforce y2storage being available
+      log.warn("Caught #{ex}")
+      log.warn("No storage-ng support - not checking for a windows partition")
+      log.warn("Assuming UTC for the hardware clock")
+      false # No windows partition found
     end
 
     # Determines whether timezone is read-only for the current product

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -1035,7 +1035,12 @@ module Yast
     end
 
     # Checks whether the system has Windows installed
+    #
+    # @return [Boolean]
     def system_has_windows?
+      # Avoid probing if the architecture is not supported for Windows
+      return false unless windows_architecture?
+
       disk_analyzer.windows_system?
     rescue NameError => ex
       # bsc#1058869: Don't enforce y2storage being available
@@ -1112,6 +1117,13 @@ module Yast
     publish :function => :Summary, :type => "string ()"
 
   protected
+
+    # Whether the architecture of the system is supported by MS Windows
+    #
+    # @return [Boolean]
+    def windows_architecture?
+      Arch.x86_64 || Arch.i386
+    end
 
     def disk_analyzer
       Y2Storage::StorageManager.instance.probed_disk_analyzer


### PR DESCRIPTION
### Problem

Detection of Windows system is quite inefficient.

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1135341
* Part of https://trello.com/c/vDzeJGkD/1413-follow-up-of-1135341-inefficient-check-for-installed-windows
* Requires https://github.com/yast/yast-storage-ng/pull/1001

### Solution

* Use new method provided by *yast2-storage-ng* to detect a Windows system.

### Tests

* Added unit tests