### PR TITLE
 Setting keyboard: Ignoring empty keyboard values

### DIFF
--- a/keyboard/src/lib/y2keyboard/strategies/kb_strategy.rb
+++ b/keyboard/src/lib/y2keyboard/strategies/kb_strategy.rb
@@ -46,6 +46,11 @@ module Y2Keyboard
       # @param keyboard_code [String] the keyboard layout (e.g. "us") to set
       # in the running the system (mostly temporary).
       def set_layout(keyboard_code)
+        if keyboard_code.nil? || keyboard_code.empty?
+          log.info "Keyboard has not been defined. Do not set it."
+          return
+        end
+
         if Yast::UI.TextMode
           begin
             Yast::Execute.on_target!("loadkeys", loadkeys_devices("tty"), keyboard_code)
@@ -65,9 +70,9 @@ module Y2Keyboard
 
     private
 
-      # set x11 keys on the fly.
-      # @param keyboard_code [String] the keyboard to set.
-      def set_x11_layout(keyboard_code)
+    # set x11 keys on the fly.
+    # @param keyboard_code [String] the keyboard to set.
+    def set_x11_layout(keyboard_code)
         x11data = get_x11_data(keyboard_code)
         return if x11data.empty?
 

--- a/keyboard/src/lib/y2keyboard/strategies/systemd_strategy.rb
+++ b/keyboard/src/lib/y2keyboard/strategies/systemd_strategy.rb
@@ -17,13 +17,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
 require "yast2/execute"
 
 module Y2Keyboard
   module Strategies
     # Class to deal with systemd keyboard configuration management.
     class SystemdStrategy
+      include Yast::Logger
+
       # @return [Array<String>] an array with all available systemd keyboard layouts codes.
       def codes
         raw_layouts = Yast::Execute.on_target!("localectl", "list-keymaps", stdout: :capture)

--- a/keyboard/src/lib/y2keyboard/strategies/systemd_strategy.rb
+++ b/keyboard/src/lib/y2keyboard/strategies/systemd_strategy.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "yast2/execute"
 
 module Y2Keyboard
@@ -32,6 +33,11 @@ module Y2Keyboard
       # Use systemd to apply a new keyboard layout in the system.
       # @param keyboard_code [String] the keyboard layout to apply in the system.
       def apply_layout(keyboard_code)
+        if keyboard_code.nil? || keyboard_code.empty?
+          log.info "Keyboard has not been defined. Do not set it."
+          return
+        end
+
         if Yast::Stage.initial
           # systemd is not available here (inst-sys).
           # do use --root option, running in chroot does not work (bsc#1074481)

--- a/keyboard/test/kb_strategy_spec.rb
+++ b/keyboard/test/kb_strategy_spec.rb
@@ -58,7 +58,7 @@ describe Y2Keyboard::Strategies::KbStrategy do
     end
 
     context "empty keyboard_code parameter" do
-      it "returns only " do
+      it "does not try to set the keyboard layout" do
         expect(kb_strategy).not_to receive(:set_x11_layout)
         expect(Yast::Execute).not_to receive(:on_target!).with(
           "loadkeys", anything, anything)

--- a/keyboard/test/kb_strategy_spec.rb
+++ b/keyboard/test/kb_strategy_spec.rb
@@ -54,8 +54,16 @@ describe Y2Keyboard::Strategies::KbStrategy do
         expect(kb_strategy).to receive(:write_udev_rule)
 
         kb_strategy.set_layout("es")
-      end      
+      end
+    end
 
-    end    
+    context "empty keyboard_code parameter" do
+      it "returns only " do
+        expect(kb_strategy).not_to receive(:set_x11_layout)
+        expect(Yast::Execute).not_to receive(:on_target!).with(
+          "loadkeys", anything, anything)
+        kb_strategy.set_layout("")
+      end
+    end
   end
 end

--- a/keyboard/test/systemd_strategy_spec.rb
+++ b/keyboard/test/systemd_strategy_spec.rb
@@ -41,13 +41,23 @@ describe Y2Keyboard::Strategies::SystemdStrategy do
   end
 
   describe "#apply_layout" do
-    it "changes the keyboard layout" do
-      new_layout = Y2Keyboard::KeyboardLayout.new("es", "Spanish")
-      expect(Yast::Execute).to receive(:on_target!).with(
-        "localectl", "set-keymap", new_layout.code
-      )
+    context "valid keyboard code" do
+      it "changes the keyboard layout" do
+        new_layout = Y2Keyboard::KeyboardLayout.new("es", "Spanish")
+        expect(Yast::Execute).to receive(:on_target!).with(
+          "localectl", "set-keymap", new_layout.code
+        )
 
-      systemd_strategy.apply_layout(new_layout.code)
+        systemd_strategy.apply_layout(new_layout.code)
+      end
+    end
+
+    context "empty keyboard code" do
+      it "returns only " do
+        expect(Yast::Execute).not_to receive(:on_target!).with(
+          "localectl", "set-keymap", anything)
+        systemd_strategy.apply_layout("")
+      end
     end
   end
 

--- a/keyboard/test/systemd_strategy_spec.rb
+++ b/keyboard/test/systemd_strategy_spec.rb
@@ -53,7 +53,7 @@ describe Y2Keyboard::Strategies::SystemdStrategy do
     end
 
     context "empty keyboard code" do
-      it "returns only " do
+      it "does not try to set the keyboard layout" do
         expect(Yast::Execute).not_to receive(:on_target!).with(
           "localectl", "set-keymap", anything)
         systemd_strategy.apply_layout("")

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 18 12:03:38 CET 2019 - schubi@suse.de
+
+- Setting keyboard: Ignoring empty keyboard values.
+  (bsc#1158994, bsc#1159210)
+- 4.2.11 
+
+-------------------------------------------------------------------
 Wed Dec  4 13:26:52 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Improve detection of Windows system (related to bsc#1135341).

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
While the installation process keyboard will be set at different places and different targets.
Depending the installation workflow the keyboard setting has already been evaluated/set or not.
It is "" if it has not been set. So in that case YaST will not try to write the keyboard setting now.
