### PR TITLE
Fix loadkeys

### DIFF
--- a/keyboard/test/kb_strategy_spec.rb
+++ b/keyboard/test/kb_strategy_spec.rb
@@ -7,17 +7,20 @@ Yast.import "UI"
 describe Y2Keyboard::Strategies::KbStrategy do
   subject(:kb_strategy) { Y2Keyboard::Strategies::KbStrategy.new }
   let(:arguments_to_apply) {"-layout es -model microsoftpro -option terminate:ctrl_alt_bksp"}
-  
 
   describe "#set_layout" do
     context "in text mode" do
       before do
         allow(Yast::UI).to receive(:TextMode).and_return(true)
+        allow(Dir).to receive(:[]).with("/dev/tty[0-9]*").and_return(["/dev/tty1", "/dev/tty2"])
+        allow(Dir).to receive(:[]).with("/dev/ttyS[0-9]*").and_return(["/dev/ttyS1"])
       end
 
       it "calls -loadkeys- on the target" do
-        expect(Yast::Execute).to receive(:on_target!).twice.with(
-          "loadkeys", anything, "es")
+        expect(Yast::Execute).to receive(:on_target!).with(
+          "loadkeys", "-C" ,"/dev/tty1", "-C", "/dev/tty2", "es")
+        expect(Yast::Execute).to receive(:on_target!).with(
+          "loadkeys", "-C" ,"/dev/ttyS1", "es")
 
         kb_strategy.set_layout("es")
       end
@@ -37,7 +40,7 @@ describe Y2Keyboard::Strategies::KbStrategy do
       it "does not call -loadkeys- on the target" do
         expect(Yast::Execute).not_to receive(:on_target!).with(
           "loadkeys", anything, "es")
-        expect(kb_strategy).to receive(:set_x11_layout)        
+        expect(kb_strategy).to receive(:set_x11_layout)
 
         kb_strategy.set_layout("es")
       end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 30 14:13:44 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- fix passing parameters to loadkeys call (bsc#1159185)
+- 4.2.13
+
+-------------------------------------------------------------------
 Thu Dec 19 14:07:30 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix incorect dialect offers (bsc#949591)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1159185

Issue: string like "-C /dev/tty1 -C /dev/tty2" is passed to cheetah which expect one option per parameter. Result of keyboard refactoring.

Fix: pass properly each parameter per one argument.