### PR TITLE
Keyboard definition in the AY configuration file: Alias AND keymap na…

### DIFF
--- a/keyboard/src/modules/Keyboard.rb
+++ b/keyboard/src/modules/Keyboard.rb
@@ -46,6 +46,7 @@ module Yast
       Yast.import "Mode"
       Yast.import "ProductFeatures"
       Yast.import "Stage"
+      Yast.import "Report"
 
       # general kb strategy which is used for temporary changes only.
       @kb_strategy = Y2Keyboard::Strategies::KbStrategy.new
@@ -281,6 +282,21 @@ module Yast
       when :language
         keyboard = GetKeyboardForLanguage(settings["language"], keyboard)
       end
+
+      # Checking if the keymap exists. Either it is the real keymap name
+      # or an alias.
+      if !Keyboards.code(keyboard)
+        # Checking if it a real keymap name
+        checked_keyboard = keyboard
+        keyboard = Keyboards.alias(checked_keyboard)
+        if !keyboard
+          # TRANSLATORS: the "%s" is the kaymap name
+          Report.Warning(_("Cannot find keymap: %s. Taking default one.") % checked_keyboard)
+          return false
+        end
+      end
+
+      # Set it with the keyboard alias name
       Set(keyboard)
       true
     end

--- a/keyboard/test/keyboard_spec.rb
+++ b/keyboard/test/keyboard_spec.rb
@@ -216,6 +216,21 @@ describe "Yast::Keyboard" do
         subject.Import({"language" => "de"}, :language)
       end
     end
+
+    context "keymap value is given instead of an alias name" do
+      it "sets the alias name" do
+        expect(subject).to receive(:Set).with("spanish")
+        subject.Import({"keymap" => "es"}, :keyboard)
+      end
+    end
+
+    context "keymap is unknown" do
+      it "reports a warning" do
+        expect(subject).not_to receive(:Set)
+        expect(Yast::Report).to receive(:Warning).with(/Cannot find keymap/)
+        subject.Import({"keymap" => "foo"}, :keyboard)
+      end
+    end
   end
 
 end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jan 20 16:35:45 CET 2020 - schubi@suse.de
+
+- Keyboard definition in the AY configuration file: Alias AND
+  keymap name is supported (bsc#1159541).
+- Reporting a warning if the defined keymap has not been found.
+- 4.2.15
+
+-------------------------------------------------------------------
 Thu Jan  2 15:13:06 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not crash when unknown keymap is set on system (bsc#1159286)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.14
+Version:        4.2.15
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
…me is supported (bsc#1159541).
**Problem**
AY configuration file:
"Keymap" flag represents an keymap alias instead of the real keymap name.

**Solution**
Both are supported now.