### PR TITLE
don't use /bin/systemctl compat symlink (bsc#1160890)

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:45:13 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemctl compat symlink (bsc#1160890)
+- 4.2.16
+
+-------------------------------------------------------------------
 Mon Jan 20 16:35:45 CET 2020 - schubi@suse.de
 
 - Keyboard definition in the AY configuration file: Alias AND

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -295,7 +295,7 @@ module Yast
           SCR.Execute(path(".target.bash_output"), cmd)
         )
         unless Stage.initial
-          cmd = "/bin/systemctl try-restart systemd-timedated.service"
+          cmd = "/usr/bin/systemctl try-restart systemd-timedated.service"
           Builtins.y2milestone(
             "restarting timedated service: %1",
             SCR.Execute(path(".target.bash_output"), cmd)

--- a/timezone/testsuite/tests/MakeProposal.out
+++ b/timezone/testsuite/tests/MakeProposal.out
@@ -2,7 +2,7 @@ Read	.etc.adjtime ["0", "0", "UTC"]
 Read	.probe.is_vmware false
 Read	.target.yast2 "timezone_raw.ycp" [$["entries":$["Europe/Berlin":"Germany", "Europe/Prague":"Czech Republic"], "name":"Europe"]]
 Execute	.target.bash_output "/usr/sbin/zic -l Europe/Prague" $[]
-Execute	.target.bash_output "/bin/systemctl try-restart systemd-timedated.service" $[]
+Execute	.target.bash_output "/usr/bin/systemctl try-restart systemd-timedated.service" $[]
 Execute	.target.bash_output "/sbin/hwclock --hctosys -u" $[]
 Execute	.target.bash_output "/bin/date \"+%c\"" $[]
 Return	["Europe / Czech Republic - Hardware Clock Set To UTC "]


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemctl` symlink is gone.

## Solution

Don't use it.