### PR TITLE
[SLE-7188] Default to SUSE NTP servers

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 12:58:47 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rely on the new Y2Network::NtpServer class (jsc#SLE-7188).
+- 4.2.18
+
+-------------------------------------------------------------------
 Thu Jan 23 13:21:01 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix exit codes for CLI for language, timezone and keyboard

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.17
+Version:        4.2.18
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -57,8 +57,8 @@ Requires:       yast2-country-data
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       rubygem(%{rb_default_ruby_abi}:ruby-dbus)
 
-# new API of ntp-client_proposal.rb
-Conflicts:      yast2-ntp-client < 4.1.5
+# Y2Network::NtpServer
+Conflicts:      yast2-ntp-client < 4.2.8
 
 %description
 Country specific data and configuration modules (language, keyboard,

--- a/timezone/src/include/timezone/dialogs.rb
+++ b/timezone/src/include/timezone/dialogs.rb
@@ -32,6 +32,9 @@
 #	Dialogs for timeone and time configuration.
 #
 # $Id$
+
+require "y2network/ntp_server"
+
 module Yast
   module TimezoneDialogsInclude
     def initialize_timezone_dialogs(include_target)
@@ -47,7 +50,6 @@ module Yast
       Yast.import "NetworkService"
       Yast.import "Package"
       Yast.import "Popup"
-      Yast.import "Product"
       Yast.import "ProductFeatures"
       Yast.import "Service"
       Yast.import "Stage"
@@ -575,12 +577,7 @@ module Yast
         @ntp_used = true
         # configure NTP client
         # to prevent misusage of ntp.org we need to distinguish opensuse and SLE usage
-        base_products = Product.FindBaseProducts
-        if base_products.any? { |p| p["name"] =~ /openSUSE/i }
-          servers = (0..3).map { |i| "#{i}.opensuse.pool.ntp.org" }
-        else
-          servers = (0..3).map { |i| "#{i}.novell.pool.ntp.org" }
-        end
+        servers = Y2Network::NtpServer.default_servers.map(&:hostname)
         @ntp_server = servers.sample
         # Dot not select a dhcp ntp server by default but add it to the offered
         # list (fate#323454)


### PR DESCRIPTION
Use the new `Y2Network::NtpServer` when proposing the default values for NTP servers.

Related PR: https://github.com/yast/yast-network/pull/1039