### PR TITLE
Add yast2-country-data as build dependency

### DIFF
--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -40,6 +40,8 @@ BuildRequires:  yast2-core >= 3.1.12
 BuildRequires:  yast2-ruby-bindings >= 3.1.26
 # Yast2::CommandLine readonly parameter
 BuildRequires:  yast2 >= 4.2.57
+# /usr/share/YaST2/data/languages
+BuildRequires:  yast2-country-data
 
 Requires:       timezone
 Requires:       yast2-perl-bindings


### PR DESCRIPTION
`yast2-country` fails to build since version 4.2.17 (https://ci.opensuse.org/job/yast-yast-country-master/44/) because files under `/usr/share/YaST2/data/languages` are needed by `Timezone` tests but the package where they belong (`yast2-country-data`) is not set as *BuildRequires* (although it is listed as a regular *Requires*).