### PR TITLE
allow optional string and map types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-country-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 --privileged -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-country-image yast-travis-ruby

--- a/keyboard/src/autoyast-rnc/keyboard.rnc
+++ b/keyboard/src/autoyast-rnc/keyboard.rnc
@@ -2,17 +2,22 @@ default namespace = "http://www.suse.com/1.0/yast2ns"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace config = "http://www.suse.com/1.0/configns"
 
-keyboard = element keyboard { keyboard_values? & keymap? }
-keymap = element keymap { text }
+include "common.rnc"
+
+keyboard = element keyboard { MAP, (keyboard_values? & keymap?) }
+keymap = element keymap { STRING }
 
 
 keyboard_values =
   element keyboard_values {
-      element capslock { BOOLEAN }? &
-      element delay    { text }? &
-      element discaps  { BOOLEAN }? &
-      element numlock  { text }? &
-      element rate     { text }? &
-      element scrlock  { BOOLEAN }? &
-      element tty      { text }?
+      MAP,
+      (
+        element capslock { BOOLEAN }? &
+        element delay    { STRING }? &
+        element discaps  { BOOLEAN }? &
+        element numlock  { STRING }? &
+        element rate     { STRING }? &
+        element scrlock  { BOOLEAN }? &
+        element tty      { STRING }?
+      )
   }

--- a/language/src/autoyast-rnc/language.rnc
+++ b/language/src/autoyast-rnc/language.rnc
@@ -2,6 +2,8 @@ default namespace = "http://www.suse.com/1.0/yast2ns"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace config = "http://www.suse.com/1.0/configns"
 
-language = element language { language_val? & languages? }
-language_val = element language { text }
-languages = element languages { text }
+include "common.rnc"
+
+language = element language { MAP, (language_val? & languages?) }
+language_val = element language { STRING }
+languages = element languages { STRING }

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  7 15:19:48 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Autoyast schema: Allow optional types for string and map objects
+  (bsc#1170886)
+- 4.3.0
+
+-------------------------------------------------------------------
 Wed Feb 19 12:58:47 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rely on the new Y2Network::NtpServer class (jsc#SLE-7188).

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.18
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/autoyast-rnc/timezone.rnc
+++ b/timezone/src/autoyast-rnc/timezone.rnc
@@ -2,7 +2,9 @@ default namespace = "http://www.suse.com/1.0/yast2ns"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace config = "http://www.suse.com/1.0/configns"
 
-timezone = element timezone { hwclock? & timezone_val? }
-hwclock = element hwclock { "localtime" | "UTC" }
-timezone_val = element timezone { text }
+include "common.rnc"
+
+timezone = element timezone { MAP, (hwclock? & timezone_val?) }
+hwclock = element hwclock { STRING_ATTR, ("localtime" | "UTC") }
+timezone_val = element timezone { STRING }
 


### PR DESCRIPTION
trello: https://trello.com/c/HkFkUQHj/1791-3-continue-with-new-xml-parser-xml-validation

depends on yast/yast-autoinstallation#598

Agreed to postpone for now that trang and jing travis validation to not delay even more new xml parser.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1170886