### PR TITLE
Do not try to restart non existing kbd service

### DIFF
--- a/keyboard/src/clients/keyboard.rb
+++ b/keyboard/src/clients/keyboard.rb
@@ -127,7 +127,6 @@ module Yast
         Popup.ShowFeedback(Message.updating_configuration, Message.takes_a_while)
       end
       Keyboard.Save
-      Service.Restart("kbd")
       Popup.ClearFeedback if Keyboard.needs_new_initrd?
       true
     end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 12 08:28:59 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- bnc#1170292
+  - do not restart non existing kbd service
+- 4.1.15
+
+-------------------------------------------------------------------
 Fri Oct 18 12:35:02 UTC 2019 - Knut Anderssen<kanderssen@suse.com>
 
 - Keyboard: Permit to set the Keyboard layout in AutoYaST config

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.1.14
+Version:        4.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1170292

## Problem

after layout change a restart of kbd service is requested during write. As the service doesn't exist, everything is blocked for approx 1 minute due to a timeout

## Solution

Backported one line from https://github.com/yast/yast-country/pull/225

