### PR TITLE
Fixed activating keyboard layout for ttyAMA devices

### DIFF
--- a/keyboard/src/lib/y2keyboard/strategies/kb_strategy.rb
+++ b/keyboard/src/lib/y2keyboard/strategies/kb_strategy.rb
@@ -59,6 +59,7 @@ module Y2Keyboard
             # be done separately in order to ensure that setting console keyboard
             # will be done successfully in the previous call.
             Yast::Execute.on_target!("loadkeys", *loadkeys_devices("ttyS"), keyboard_code)
+            Yast::Execute.on_target!("loadkeys", *loadkeys_devices("ttyAMA"), keyboard_code)
           rescue Cheetah::ExecutionFailed => e
             log.info(e.message)
             log.info("Error output:    #{e.stderr}")

--- a/keyboard/test/kb_strategy_spec.rb
+++ b/keyboard/test/kb_strategy_spec.rb
@@ -14,6 +14,7 @@ describe Y2Keyboard::Strategies::KbStrategy do
         allow(Yast::UI).to receive(:TextMode).and_return(true)
         allow(Dir).to receive(:[]).with("/dev/tty[0-9]*").and_return(["/dev/tty1", "/dev/tty2"])
         allow(Dir).to receive(:[]).with("/dev/ttyS[0-9]*").and_return(["/dev/ttyS1"])
+        allow(Dir).to receive(:[]).with("/dev/ttyAMA[0-9]*").and_return(["/dev/ttyAMA0"])
       end
 
       it "calls -loadkeys- on the target" do
@@ -21,6 +22,8 @@ describe Y2Keyboard::Strategies::KbStrategy do
           "loadkeys", "-C" ,"/dev/tty1", "-C", "/dev/tty2", "es")
         expect(Yast::Execute).to receive(:on_target!).with(
           "loadkeys", "-C" ,"/dev/ttyS1", "es")
+        expect(Yast::Execute).to receive(:on_target!).with(
+          "loadkeys", "-C" ,"/dev/ttyAMA0", "es")
 
         kb_strategy.set_layout("es")
       end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun  1 07:11:31 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- bnc#1172180 
+  - activates keyboard layout also for ttyAMA devices
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May  7 15:19:48 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
keyboard known only ttyS* serial ports. So, I've added loadkeys call also for ttyAMA* devices

https://bugzilla.suse.com/show_bug.cgi?id=1172180