### PR TITLE
Avoid yast2-country-data build dependency

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 23 10:04:37 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Avoid build-require of yast2-country-data subpackage
+  (bsc#1173253).
+- 4.3.2
+
+-------------------------------------------------------------------
 Mon Jun  1 07:11:31 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bnc#1172180 

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -40,8 +40,6 @@ BuildRequires:  yast2-core >= 3.1.12
 BuildRequires:  yast2-ruby-bindings >= 3.1.26
 # Yast2::CommandLine readonly parameter
 BuildRequires:  yast2 >= 4.2.57
-# /usr/share/YaST2/data/languages
-BuildRequires:  yast2-country-data
 
 Requires:       timezone
 Requires:       yast2-perl-bindings

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -6,9 +6,7 @@ require "y2country/language_dbus"
 Yast.import "ProductFeatures"
 
 describe "Yast::Timezone" do
-  let(:readonly_timezone) { false }
-  let(:default_timezone) { "" }
-  let(:initial) { false }
+  subject { Yast::Timezone }
 
   before do
     # Do not run any command on system
@@ -22,9 +20,20 @@ describe "Yast::Timezone" do
       .with("globals", "timezone").and_return(default_timezone)
     allow(Yast::Stage).to receive(:initial).and_return(initial)
     Yast::Timezone.main
+
+    allow(Yast::Language).to receive(:GetLang2TimezoneMap).and_return(timezones)
   end
 
-  subject { Yast::Timezone }
+  let(:readonly_timezone) { false }
+  let(:default_timezone) { "" }
+  let(:initial) { false }
+
+  let(:timezones) do
+    {
+      "en_US" => "US/Eastern",
+      "cs_CZ" => "Europe/Prague"
+    }
+  end
 
   describe "#ProposeLocaltime" do
     subject { Yast::Timezone.ProposeLocaltime }


### PR DESCRIPTION
## Problem

Package yast2-country has a build dependency of its sub-package yast2-country-data. This is a chicken-egg problem. That build dependency was added here https://github.com/yast/yast-country/pull/244 because some issues with unit tests.

Now a build problem is raising when performing a full distro bootstrap.

* https://bugzilla.suse.com/show_bug.cgi?id=1173253

## Solution

Missing mocking was added to unit tests and now the build dependency is not needed anymore.
