### PR TITLE
Expose default language

### DIFF
--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -40,6 +40,8 @@ module Yast
 
     require "y2country/language_dbus"
 
+    attr_reader :default_language
+
     def main
       Yast.import "Pkg"
       Yast.import "UI"

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  1 14:36:38 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Language: added a default language reader (bsc#1173498)
+- 4.1.16
+
+-------------------------------------------------------------------
 Tue May 12 08:28:59 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bnc#1170292

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.1.15
+Version:        4.1.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Added a reader in order to check which is the current default language. (needed by yast/yast-firstboot#98)
