### PR TITLE
Fixed failing unit test on S390

### DIFF
--- a/keyboard/test/keyboard_auto_test.rb
+++ b/keyboard/test/keyboard_auto_test.rb
@@ -32,9 +32,17 @@ describe Keyboard::AutoClient do
         .and_return(true)
     end
 
-    it "runs keyboard client" do
+    it "runs keyboard client on non s390" do
       expect(Yast::WFM).to receive(:CallFunction).with(
         "keyboard")
+      expect(Yast::Arch).to receive(:s390).and_return(false)
+      client.change
+    end
+
+    it "does not run keyboard client on s390" do
+      expect(Yast::WFM).to_not receive(:CallFunction).with(
+        "keyboard")
+      expect(Yast::Arch).to receive(:s390).and_return(true)
       client.change
     end
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 12 08:18:47 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed failing unit test on S390 (related to bsc#1172749)
+- 4.3.7
+
+-------------------------------------------------------------------
 Wed Jul  1 11:09:54 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - avoid build dependency on yast2-network to break build loop

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
- We build the YaST:Head packages only for x86_64 so this missing `Arch` mock was not found
- 4.3.7