### PR TITLE
adjust keyboard client layout to also fit the firstboot workflow (bsc#1174856)

### DIFF
--- a/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
+++ b/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
@@ -96,7 +96,9 @@ module Y2Keyboard
         finish_dialog(:abort)
       end
 
-      alias_method :abort_handler, :cancel_handler
+      def abort_handler
+        cancel_handler if Yast::Popup.ConfirmAbort(:painless)
+      end
 
       def layout_list_handler
         if !Yast::Mode.config # not in AY configuration module

--- a/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
+++ b/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
@@ -25,6 +25,7 @@ require_relative "../keyboard_layout"
 Yast.import "UI"
 Yast.import "Popup"
 Yast.import "Mode"
+Yast.import "Stage"
 
 module Y2Keyboard
   module Dialogs
@@ -47,7 +48,7 @@ module Y2Keyboard
             HWeight(50, layout_selection_box),
             HWeight(20, HStretch())
           ),
-          footer
+          Yast::Stage.firstboot ? footer_firstboot : footer
         )
       end
 
@@ -79,12 +80,23 @@ module Y2Keyboard
         finish_dialog(:accept)
       end
 
+      def next_handler
+        selected_layout.apply_layout
+        finish_dialog(:next)
+      end
+
+      def back_handler
+        finish_dialog(:back)
+      end
+
       def cancel_handler
         if !Yast::Mode.config # not in AY configuration module
           KeyboardLayoutLoader.load_layout(@previous_selected_layout)
         end
         finish_dialog(:abort)
       end
+
+      alias_method :abort_handler, :cancel_handler
 
       def layout_list_handler
         if !Yast::Mode.config # not in AY configuration module
@@ -123,6 +135,17 @@ module Y2Keyboard
           Left(PushButton(Id(:help), Opt(:key_F1, :help), Yast::Label.HelpButton)),
           PushButton(Id(:cancel), Yast::Label.CancelButton),
           PushButton(Id(:accept), Yast::Label.AcceptButton),
+          HSpacing()
+        )
+      end
+
+      def footer_firstboot
+        HBox(
+          HSpacing(),
+          Left(PushButton(Id(:help), Opt(:key_F1, :help), Yast::Label.HelpButton)),
+          PushButton(Id(:abort), Yast::Label.AbortButton),
+          PushButton(Id(:back), Yast::Label.BackButton),
+          PushButton(Id(:next), Yast::Label.NextButton),
           HSpacing()
         )
       end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 13 11:21:03 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- adjust keyboard client layout to also fit the firstboot workflow
+  (bsc#1174856)
+- 4.2.19
+
+-------------------------------------------------------------------
 Wed Feb 19 12:58:47 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rely on the new Y2Network::NtpServer class (jsc#SLE-7188).

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.18
+Version:        4.2.19
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1174856
- https://trello.com/c/mVt37N0M

The `firstboot_keyboard` client is out of date and doesn't work with the current `yast-country` code.

## Solution

I could not find a compelling reason why there has to be a separate `firstboot_keyboard` client in the first place. It seems pointless to more or less copy-and-paste reproduce the `keyboard` client code.

So why not use the `keyboard` client directly instead? All it needs (AFAICS) is adjusting the workflow buttons to be aligned with firstboot expectations.

## Screenshots

![q](https://user-images.githubusercontent.com/927244/95757299-444e8380-0ca7-11eb-9839-76ead319ebff.png)
![n](https://user-images.githubusercontent.com/927244/95757319-4a446480-0ca7-11eb-857e-14d6fd85867c.png)

## See also

- https://github.com/yast/yast-firstboot/pull/107