### PR TITLE
Adapt unit test to recent changes in Yast::Report

### DIFF
--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -374,12 +374,13 @@ describe "Yast::Language" do
         let(:lang) { "ar_EG" }
 
         it "changes the language to English" do
+          allow(Yast::Report).to receive(:Message)
           expect(subject).to receive(:WfmSetGivenLanguage).with("en_US")
           subject.SwitchToEnglishIfNeeded(true)
         end
 
         it "displays an error message if asked to do so" do
-          allow(Yast::Report).to receive(:Message).with(/selected language cannot be used/)
+          expect(Yast::Report).to receive(:Message).with(/selected language cannot be used/)
           subject.SwitchToEnglishIfNeeded(true)
         end
 
@@ -389,6 +390,7 @@ describe "Yast::Language" do
         end
 
         it "returns true" do
+          allow(Yast::Report).to receive(:Message)
           expect(subject.SwitchToEnglishIfNeeded(true)).to eq(true)
         end
       end
@@ -410,6 +412,7 @@ describe "Yast::Language" do
         let(:lang) { "ja_JP" }
 
         it "changes the language to English" do
+          allow(Yast::Report).to receive(:Message)
           expect(subject).to receive(:WfmSetGivenLanguage).with("en_US")
           subject.SwitchToEnglishIfNeeded(true)
         end
@@ -425,6 +428,7 @@ describe "Yast::Language" do
         end
 
         it "returns true" do
+          allow(Yast::Report).to receive(:Message)
           expect(subject.SwitchToEnglishIfNeeded(true)).to eq(true)
         end
       end

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 12 13:54:28 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893)
+- 4.3.12
+
+-------------------------------------------------------------------
 Tue Dec 15 14:49:46 UTC 2020 - Stefan Schubert <schubi@suse.de>
 
 - Removed old code for sysvinit configuration (bsc#1175494).

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.3.11
+Version:        4.3.12
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.