### PR TITLE
Fix failing unit test

### DIFF
--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -15,7 +15,6 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
 Name:           yast2-country
 Version:        4.3.14
 Release:        0
@@ -38,6 +37,8 @@ BuildRequires:  yast2-core >= 3.1.12
 BuildRequires:  yast2-ruby-bindings >= 3.1.26
 # Yast2::CommandLine readonly parameter
 BuildRequires:  yast2 >= 4.2.57
+# systemd-mini does not add the xkb generated map
+BuildRequires:  systemd
 
 Requires:       timezone
 Requires:       yast2-perl-bindings


### PR DESCRIPTION
## Problem

As part of [this](https://github.com/yast/yast-country/pull/266) PR a unit test was introduced in order to verify the keyboard layout mapping.

https://github.com/yast/yast-country/pull/266/files#diff-299636c1b42b787c000e11ed239568da530b181d5c67886c9d2ea7f640896e26R11

The problem is that the the build package (which uses systemd-mini) does not contains the map generated by kbd.

So, the Jenkins jobs for submitting the changes failed because it expected /usr/share/systemd/kbd-model-map to contain 'es-ast', tw and cn.

## Solution

- Add systemd as a build dependency (maybe it is not the best solution but looks better than skip the test)