### PR TITLE
bsc#1187270: fix control center tooltip (SLE-15-SP2)

### DIFF
--- a/timezone/src/desktop/org.opensuse.yast.Timezone.desktop
+++ b/timezone/src/desktop/org.opensuse.yast.Timezone.desktop
@@ -22,5 +22,5 @@ Exec=xdg-su -c "/sbin/yast2 timezone"
 
 Name=YaST Date and Time
 GenericName=Date and Time
-Comment=Control time zone, date, and system time
+Comment="Control time zone, date, and system time"
 StartupNotify=true


### PR DESCRIPTION
Related to [bsc#1187270](https://bugzilla.opensuse.org/show_bug.cgi?id=1187270).

See [the original issue](https://github.com/yast/yast-users/pull/303) in the yast2-users module.