### PR TITLE
bsc#1187270: fix control center tooltip

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the Comment entry in the desktop file so the tooltip
+  in the control center is properly translated (bsc#1187270).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/desktop/org.opensuse.yast.Timezone.desktop
+++ b/timezone/src/desktop/org.opensuse.yast.Timezone.desktop
@@ -22,5 +22,5 @@ Exec=xdg-su -c "/sbin/yast2 timezone"
 
 Name=YaST Date and Time
 GenericName=Date and Time
-Comment=Control time zone, date, and system time
+Comment="Control time zone, date, and system time"
 StartupNotify=true


### PR DESCRIPTION
Related to [bsc#1187270](https://bugzilla.opensuse.org/show_bug.cgi?id=1187270).

See [the original issue](https://github.com/yast/yast-users/pull/303) in the yast2-users module.