### PR TITLE
Add normalized azerty layout

### DIFF
--- a/keyboard/src/data/keyboards.rb
+++ b/keyboard/src/data/keyboards.rb
@@ -55,6 +55,11 @@ class Keyboards
         "code" => "fr-latin1",
         "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
       },
+      { "description" => _("French (AFNOR)"),
+        "alias" => "french",
+        "code" => "fr-afnor",
+        "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
+      },
       { "description" => _("French (Switzerland)"),
         "alias" => "french-ch",
         "code" => "fr_CH-latin1",

--- a/keyboard/src/data/keyboards.rb
+++ b/keyboard/src/data/keyboards.rb
@@ -25,6 +25,16 @@ class Keyboards
 
   textdomain "country"
 
+  # @return [Array<Hash{String => Object}>] keyboard descriptions
+  #
+  #   - description [String] translated name of layout
+  #   - alias [String] yast-internal keybord id, to match the "keyboard" key
+  #       in language/src/data/languages/language_*.ycp
+  #   - code [String] keyboard name used by kbd, and
+  #       present in /usr/share/systemd/kbd-model-map
+  #       (test/data/keyboard_test.rb checks this)
+  #   - suggested_for_lang [Array<String>] optional, language codes
+  #       to suggest this layout for
   def self.all_keyboards
     [
       { "description" => _("English (US)"),

--- a/keyboard/src/data/keyboards.rb
+++ b/keyboard/src/data/keyboards.rb
@@ -56,7 +56,7 @@ class Keyboards
         "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
       },
       { "description" => _("French (AFNOR)"),
-        "alias" => "french",
+        "alias" => "french-afnor",
         "code" => "fr-afnor",
         "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
       },

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 28 16:10:33 UTC 2021 - Martin Vidner <mvidner@suse.com>
+
+-  Add the AFNOR standardized French keyboard layout (NF Z71-300)
+   (bsc#1188867)
+-  4.4.2
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
This keyboard layout is the normalized (i.e. defined by the French authority of normalization AFNOR) version of the azerty layout. It’s a major improvement and was [released in 2019](https://normalisation.afnor.org/actualites/faq-clavier-francais/). It’s already made its way into `kbd` and `xkeyboard-config` a while ago:
```sh
> rpm -ql kbd | grep fr-afnor
/usr/share/kbd/keymaps/xkb/fr-afnor.map.gz
> grep -w afnor /usr/share/X11/xkb/symbols/fr
// Normalization: https://normalisation.afnor.org/actualites/faq-clavier-francais/
xkb_symbols "afnor" {
```