### PR TITLE
Comment how to switch some keyboard layouts (bsc#1184452)

### DIFF
--- a/keyboard/src/data/keyboards.rb
+++ b/keyboard/src/data/keyboards.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "yast/i18n"
 
+# Linux console keyboard layouts
 class Keyboards
   extend Yast::I18n
 
@@ -110,6 +111,8 @@ class Keyboards
       },
       { "description" => _("Greek"),
         "alias" => "greek",
+        # Left-shift+Alt switches layouts
+        # Windows (Super) is a Greek-shift
         "code" => "gr"
       },
       { "description" => _("Dutch"),
@@ -198,6 +201,8 @@ class Keyboards
       },
       { "description" => _("Dvorak"),
         "alias" => "dvorak",
+        # Beware, Dvorak is completely different from QWERTY;
+        # see also https://en.wikipedia.org/wiki/Dvorak_keyboard_layout
         "code" => "dvorak"
       },
       { "description" => _("Icelandic"),
@@ -207,6 +212,7 @@ class Keyboards
       },
       { "description" => _("Ukrainian"),
         "alias" => "ukrainian",
+        # AltGr or Right-Ctrl switch layouts
         "code" => "ua-utf"
       },
       { "description" => _("Khmer"),
@@ -223,6 +229,7 @@ class Keyboards
       },
       { "description" => _("Tajik"),
         "alias" => "tajik",
+        # AltGr switches layouts
         "code" => "tj_alt-UTF8"
       },
       { "description" => _("Traditional Chinese"),


### PR DESCRIPTION
In https://bugzilla.suse.com/show_bug.cgi?id=1184452 testers say that some keyboard layouts don't work.
In fact they do work but the primary layout is US and you have to switch to the national layout. This is sometimes written as a comment in the .map.gz file, sometimes not even that.

