### PR TITLE
Offer the fr-afnor keyboard only if it is defined (bsc#1188867) 

### DIFF
--- a/keyboard/src/data/keyboards.rb
+++ b/keyboard/src/data/keyboards.rb
@@ -37,6 +37,11 @@ class Keyboards
   #   - suggested_for_lang [Array<String>] optional, language codes
   #       to suggest this layout for
   def self.all_keyboards
+    always_present_keyboards + optional_keyboards
+  end
+
+  # @see all_keyboards
+  def self.always_present_keyboards
     [
       { "description" => _("English (US)"),
         "alias" => "english-us",
@@ -64,11 +69,6 @@ class Keyboards
       { "description" => _("French"),
         "alias" => "french",
         "code" => "fr-latin1",
-        "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
-      },
-      { "description" => _("French (AFNOR)"),
-        "alias" => "french-afnor",
-        "code" => "fr-afnor",
         "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
       },
       { "description" => _("French (Switzerland)"),
@@ -264,6 +264,31 @@ class Keyboards
         "code" => "us-acentos"
       }
     ]
+  end
+
+  # Some keyboards are present in new openSUSE releases but not in older SLE
+  # @see all_keyboards
+  def self.optional_keyboards
+    # memoize this
+    return @optional_keyboards unless @optional_keyboards.nil?
+
+    @optional_keyboards = []
+
+    # The afnor layout was added to xkeyboard-config in 2019-06
+    # but SLE15-SP4 only has 2.23 released in 2018
+    afnor_test = lambda do
+      kmm = File.read("/usr/share/systemd/kbd-model-map") rescue ""
+      kmm.match?("^fr-afnor")
+    end
+    afnor = {
+      "description" => _("French (AFNOR)"),
+      "alias" => "french-afnor",
+      "code" => "fr-afnor",
+      "suggested_for_lang" => ["br_FR", "fr", "fr_BE"]
+    }
+    @optional_keyboards.push(afnor) if afnor_test.call
+
+    @optional_keyboards
   end
 
   # Evaluate the proposed keyboard for a given language

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  5 10:21:22 UTC 2021 - Martin Vidner <mvidner@suse.com>
+
+- Offer the fr-afnor keyboard only if it is defined (bsc#1188867)
+  It is not part of SLE15 so far.
+- 4.4.4
+
+-------------------------------------------------------------------
 Tue Aug  3 16:38:40 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: allow empty /profile/timezone/timezone setting,

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1188867
- An amendment to #273: after merging it turned out that the internal Jenkins job fails because the SLE environment is different.

This change checks at run time whether the new French layout is present and filters it out if it's not.

There may be an option to add the layout to SLE15 instead, I'll ask the maintainers+release managers in Bugzilla.

### Testing

I have tested this by applying the following patch and inspecting the output of `rake osc:build` for `master` and `SLE-15-SP3`, with results being true and false respectively:
```diff
diff --git a/keyboard/test/data/keyboard_test.rb b/keyboard/test/data/keyboard_test.rb
index ed5c03a..10c1ccd 100644
--- a/keyboard/test/data/keyboard_test.rb
+++ b/keyboard/test/data/keyboard_test.rb
@@ -14,6 +14,8 @@ describe Keyboards do
         code = kb_map["code"]
         expect(valid_codes).to include(code)
       end
+      a = Keyboards.all_keyboards.any? { |k| k["code"] == "fr-afnor" }
+      puts "HAVE AFNOR: #{a}"
     end
   end
 end
```