### PR TITLE
Do not write empty timezone

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug  3 16:38:40 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Do not write an empty timezone (bsc#1188406).
+- 4.2.22
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Tue Aug  3 16:38:40 UTC 2021 - José Iván López González <jlopez@suse.com>
 
-- Do not write an empty timezone (bsc#1188406).
+- AutoYaST: allow empty /profile/timezone/timezone setting,
+  meaning to keep the UTC default (bsc#1188406).
 - 4.2.22
 
 -------------------------------------------------------------------
@@ -3454,4 +3455,3 @@ Fri Jun 28 14:38:44 CEST 2002 - fehr@suse.de
 Mon Jun 24 10:38:11 CEST 2002 - kkaempf@suse.de
 
 - Initial version, merge console, keyboard, language, and timezone.
-

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-country
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -837,27 +837,7 @@ module Yast
         return
       end
 
-      cmd = if Stage.initial
-        # do use --root option, running in chroot does not work
-        "/usr/bin/systemd-firstboot --root '#{Installation.destdir}' --timezone '#{@timezone}'"
-      else
-        # this sets both the locale (see "man localectl")
-        "/usr/bin/timedatectl set-timezone #{@timezone}"
-      end
-      log.info "Making timezone setting persistent: #{cmd}"
-      result = if Stage.initial
-        WFM.Execute(path(".local.bash_output"), cmd)
-      else
-        SCR.Execute(path(".target.bash_output"), cmd)
-      end
-      if result["exit"] != 0
-        log.error "Timezone configuration not written. Failed to execute '#{cmd}'"
-        log.error "output: #{result.inspect}"
-        # TRANSLATORS: the "%s" is replaced by the executed command
-        Report.Error(_("Could not save the timezone setting, the command\n%s\nfailed.") % cmd)
-      else
-        log.info "output: #{result.inspect}"
-      end
+      write_timezone
 
       SCR.Write(path(".sysconfig.clock.DEFAULT_TIMEZONE"), @default_timezone)
 
@@ -1124,6 +1104,40 @@ module Yast
 
     def disk_analyzer
       Y2Storage::StorageManager.instance.probed_disk_analyzer
+    end
+
+    # Writes the timezone configuration
+    def write_timezone
+      if @timezone.nil? || @timezone.strip.empty?
+        log.warn("Timezone configuration not written. No value was given.")
+        return
+      end
+
+      cmd = if Stage.initial
+        # do use --root option, running in chroot does not work
+        "/usr/bin/systemd-firstboot --root '#{Installation.destdir}' --timezone '#{@timezone}'"
+      else
+        # this sets both the locale (see "man localectl")
+        "/usr/bin/timedatectl set-timezone #{@timezone}"
+      end
+
+      log.info "Making timezone setting persistent: #{cmd}"
+
+      result = if Stage.initial
+        WFM.Execute(path(".local.bash_output"), cmd)
+      else
+        SCR.Execute(path(".target.bash_output"), cmd)
+      end
+
+      if result["exit"] != 0
+        log.error "Timezone configuration not written. Failed to execute '#{cmd}'"
+        log.error "output: #{result.inspect}"
+
+        # TRANSLATORS: the "%s" is replaced by the executed command
+        Report.Error(_("Could not save the timezone setting, the command\n%s\nfailed.") % cmd)
+      else
+        log.info "output: #{result.inspect}"
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

If the AutoYaST profile specifies an empty timezone (e.g., `<timezone/>`), then an error popup is shown at the end of the installation . Basically, the commands for setting the timezone (i.e., *systemd-firstboot --timezone* and *timedatectl set-timezone*) cannot be called without a timezone value.

* https://bugzilla.suse.com/show_bug.cgi?id=1188406

## Solution

Avoid to set the timezone if no timezone was given. Note that UTF timezone is used by default.

NOTE: The bug was reported for SLE-15-SP3, but it affects to SLE-15-SP2 as well and SP2 maintenance ends on 31 Dec 2021.

## Testing

* Unit tests.
* Manually tested.
 