### PR TITLE
Use only one server when configuring the Timezone during installation

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  6 13:48:04 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Use only one server when proposing the default NTP servers to
+  be used (bsc#1188980).
+- 4.4.6
+
+-------------------------------------------------------------------
 Wed Aug 18 10:23:48 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Move the keyboards database to lib/ to make the module compatible

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/include/timezone/dialogs.rb
+++ b/timezone/src/include/timezone/dialogs.rb
@@ -574,11 +574,10 @@ module Yast
         # configure NTP client
         # to prevent misusage of ntp.org we need to distinguish opensuse and SLE usage
         require "y2network/ntp_server"
-        servers = Y2Network::NtpServer.default_servers.map(&:hostname)
-        @ntp_server = servers.sample
+        @ntp_server = Y2Network::NtpServer.default_servers.map(&:hostname).sample
         # Dot not select a dhcp ntp server by default but add it to the offered
-        # list (fate#323454)
-        servers = ntp_call("dhcp_ntp_servers", {}).concat(servers).uniq
+        # list (fate#323454). Add only one server as it is added as a pool (bsc#1188980)
+        servers = ntp_call("dhcp_ntp_servers", {}).concat([@ntp_server].compact).uniq
         argmap = {
           "server"       => @ntp_server,
           # FIXME ntp-client_proposal doesn't understand 'servers' yet


### PR DESCRIPTION
## Problem

During installation (TW, SLE) we use all the default NTP servers and write them down to /etc/chrony.conf as pool servers.

By default (see https://bugzilla.suse.com/show_bug.cgi?id=1180689) a chrony pool config is suggested containing only one server (based on RPM selection).

That currently means 5 pools and the corresponding NTP servers as chrony sources.

- https://bugzilla.suse.com/show_bug.cgi?id=1188980
- https://trello.com/c/HtBLfvR0/2280-3-ostumbleweed-p5-1180699-microos-defaults-to-using-the-suse-ntp-pool

## Solution

Do not use all the default servers but just one of them as it is configured as a pool and not as a single NTP server following the RPM approach.

## Screenshots

| Before | After |
| ------- | ------ |
| ![NtpServersMultiple](https://user-images.githubusercontent.com/7056681/132244171-21002314-c491-4bd2-8d41-284b2e7769da.png) | ![NtpServers](https://user-images.githubusercontent.com/7056681/132244184-853e0378-1a06-4ae6-a4be-ce5721007326.png) |
