### PR TITLE
Fix Obsolete Chinese Time Zones (SLE-15 SP3)

### DIFF
--- a/timezone/src/data/timezone_raw.ycp
+++ b/timezone/src/data/timezone_raw.ycp
@@ -522,8 +522,6 @@ $[
 	// time zone
 	"Asia/Gaza"		: _("Gaza"),
 	// time zone
-	"Asia/Harbin"		: _("Harbin"),	// CN
-	// time zone
 	"Asia/Hong_Kong"	: _("Hongkong"),
 	// time zone
 	"Asia/Hovd"		: _("Hovd"),	// MN
@@ -603,8 +601,6 @@ $[
 	"Asia/Tokyo"		: _("Tokyo"),
 	// time zone
 	"Asia/Shanghai"		: _("Shanghai"),
-	// time zone
-	"Asia/Beijing"		: _("Beijing"),
 	// time zone
 	"Asia/Taipei"		: _("Taipei"),
 	// time zone

--- a/timezone/src/lib/y2country/clients/timezone_auto.rb
+++ b/timezone/src/lib/y2country/clients/timezone_auto.rb
@@ -26,7 +26,9 @@ module Yast
     end
 
     def import(data)
-      Timezone.Import(data)
+      result = Timezone.Import(data)
+      fix_obsolete_timezones
+      result
     end
 
     def summary
@@ -60,7 +62,18 @@ module Yast
     end
     
     def modified
-      Timezone.modified = true      
+      Timezone.modified = true
+    end
+
+    def fix_obsolete_timezones
+      old_timezone = Timezone.timezone
+      new_timezone = Timezone.UpdateTimezone(old_timezone)
+      return if new_timezone == old_timezone
+
+      Timezone.Set(new_timezone, true)
+      Timezone.modified = true
+      log.info("Changed obsolete timezone #{old_timezone} to #{new_timezone}")
+      nil
     end
   end
 end

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -137,6 +137,8 @@ module Yast
         "Mexico/BajaSur"           => "America/Mazatlan",
         "Mexico/General"           => "America/Mexico_City",
         "Jamaica"                  => "America/Jamaica",
+        "Asia/Beijing"             => "Asia/Shanghai",
+        "Asia/Harbin"              => "Asia/Shanghai",
         "Asia/Macao"               => "Asia/Macau",
         "Israel"                   => "Asia/Jerusalem",
         "Asia/Tel_Aviv"            => "Asia/Jerusalem",

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -76,7 +76,7 @@ module Yast
 
       @diff = 0
 
-      # if anyuthing was modified (currently for auto client only)
+      # if anything was modified (currently for auto client only)
       @modified = false
 
       # If there is windows partition, assume that local time is used
@@ -975,7 +975,7 @@ module Yast
         @hwclock = Ops.get_string(settings, "hwclock", "UTC") == "UTC" ? "-u" : "--localtime"
         @user_hwclock = true
       end
-      # FIXME: this set modify system which is a bit unusual for import operation
+      # FIXME: this set modifies the system which is very unusual for an import operation
       Set(Ops.get_string(settings, "timezone", @timezone), true)
       true
     end

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -558,12 +558,23 @@ describe "Yast::Timezone" do
   end
 
   describe "#UpdateTimezone" do
-    it "returns its param if it is non obsolete timezone" do
+    it "returns its param if it is a non-obsolete timezone" do
       expect(subject.UpdateTimezone("Australia/Adelaide")).to eq "Australia/Adelaide"
     end
 
-    it "returns replacement for obsolete timezone" do
+    it "returns a replacement for an obsolete timezone" do
       expect(subject.UpdateTimezone("US/Pacific")).to eq "America/Los_Angeles"
+    end
+
+    it "fixes obsolete Chinese timezones (bsc#1190586)" do
+      expect(subject.UpdateTimezone("Asia/Beijing")).to eq "Asia/Shanghai"
+      expect(subject.UpdateTimezone("Asia/Harbin")).to eq "Asia/Shanghai"
+    end
+    
+    it "keeps valid Chinese timezones (bsc#1190586)" do
+      expect(subject.UpdateTimezone("Asia/Shanghai")).to eq "Asia/Shanghai"
+      expect(subject.UpdateTimezone("Asia/Hong_Kong")).to eq "Asia/Hong_Kong"
+      expect(subject.UpdateTimezone("Asia/Macau")).to eq "Asia/Macau"
     end
   end
 


### PR DESCRIPTION
**_This is the fix for SLE-15 SP3._**

## Trello

https://trello.com/c/bC5YhSAa/


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1190586


## Problem

Obsolete time zones for China are confusing some applications that have greatly increased importance since home office has become so much more important. This includes MS Teams, among others.

China has only one single very large official time zone that spans the whole country (which used to have 4 or 5 because it extends so far from the West to the East); all of China is now officially UTC+8 (no daylight savings time), and the time zone is called **_Asia/Shanghai_** (according to the IANA standard) because that's the largest population center (not Beijing, the capital).

Other time zones are really synonyms / aliases for it, yet they are not official, and they are what confuses that software:

- Asia/Beijing
- Asia/Harbin

Some others have the same numeric value (also UTC+8; also no DST), yet are officially recognized as valid aliases:

- Asia/Hong_Kong
- Asia/Macau

There is one other that is used in parallel (!) to the _Asia/Shanghai_ time zone in the Western part of the country:

- Asia/Urumqi (UTC+6)


### Reference

https://en.wikipedia.org/wiki/Time_in_China


## Fix

This PR doesn't offer the obsolete ones _Asia/Beijing_ and _Asia/Harbin_ to _Asia/Shanghai_  in the YaST UI anymore, i.e. in the time zones world map and in the corresponding selection lists).

It changes the obsolete time zones in AutoYaST upon data import and logs that to the y2log.

The aliases as well as the one that is used in parallel in the Western part are left unchanged:

- Asia/Hong_Kong
- Asia/Macau
- Asia/Urumqi
