### PR TITLE
Unify YaST module mocking in unit tests

### DIFF
--- a/console/test/console_test.rb
+++ b/console/test/console_test.rb
@@ -18,6 +18,8 @@ describe "Yast::Console" do
     let(:full_language) { "es_ES.UTF-8" }
     let(:language) { "es_ES" }
     let(:os_release_id) { "sles" }
+    # read it from the system, it might be different in Leap and Tumbleweed
+    let(:default_encoding) { `LC_CTYPE=#{language} locale charmap`.strip }
 
     before do
       allow(Yast::Linuxrc).to receive(:braille).and_return(braille)
@@ -31,7 +33,7 @@ describe "Yast::Console" do
     end
 
     it "returns the encoding" do
-      expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1")
+      expect(Yast::Console.SelectFont(language)).to eq(default_encoding)
     end
 
     context "when no console font is available" do
@@ -41,7 +43,7 @@ describe "Yast::Console" do
       end
 
       it "returns the encoding" do
-        expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1")
+        expect(Yast::Console.SelectFont(language)).to eq(default_encoding)
       end
     end
 

--- a/console/test/console_test.rb
+++ b/console/test/console_test.rb
@@ -18,8 +18,6 @@ describe "Yast::Console" do
     let(:full_language) { "es_ES.UTF-8" }
     let(:language) { "es_ES" }
     let(:os_release_id) { "sles" }
-    # read it from the system, it might be different in Leap and Tumbleweed
-    let(:default_encoding) { `LC_ALL=#{language} LC_CTYPE=#{language} locale charmap`.strip }
 
     before do
       allow(Yast::Linuxrc).to receive(:braille).and_return(braille)
@@ -33,7 +31,8 @@ describe "Yast::Console" do
     end
 
     it "returns the encoding" do
-      expect(Yast::Console.SelectFont(language)).to eq(default_encoding)
+      # Leap uses ISO defaults, Tumbleweed UTF-8
+      expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8")
     end
 
     context "when no console font is available" do
@@ -43,7 +42,8 @@ describe "Yast::Console" do
       end
 
       it "returns the encoding" do
-        expect(Yast::Console.SelectFont(language)).to eq(default_encoding)
+        # Leap uses ISO defaults, Tumbleweed UTF-8
+        expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8")
       end
     end
 

--- a/console/test/console_test.rb
+++ b/console/test/console_test.rb
@@ -19,7 +19,7 @@ describe "Yast::Console" do
     let(:language) { "es_ES" }
     let(:os_release_id) { "sles" }
     # read it from the system, it might be different in Leap and Tumbleweed
-    let(:default_encoding) { `LC_CTYPE=#{language} locale charmap`.strip }
+    let(:default_encoding) { `LC_ALL=#{language} LC_CTYPE=#{language} locale charmap`.strip }
 
     before do
       allow(Yast::Linuxrc).to receive(:braille).and_return(braille)

--- a/language/test/widgets/language_selection_test.rb
+++ b/language/test/widgets/language_selection_test.rb
@@ -23,6 +23,7 @@ describe "Y2Country::Widgets::LanguageSelection" do
     allow(Yast::Language).to receive(:GetLanguageItems)
     allow(Yast::Language).to receive(:GetLanguageItems)
       .with(:first_screen).and_return(LANGUAGE_ITEMS)
+    allow(Yast::WFM).to receive(:SetLanguage)
   end
 
   shared_examples "switch language" do |method|

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 21 08:27:16 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Unify YaST module mocking in unit tests (related to bsc#1194784)
+- 4.4.9
+
+-------------------------------------------------------------------
 Wed Jan 19 09:27:28 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - Switch console keyboard layouts to match the X11 ones

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only
@@ -33,8 +33,8 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # Fix to bnc#891053 (proper reading of ".target.yast2" on chroots)
 BuildRequires:  yast2-core >= 3.1.12
-# RSpec extensions for YaST
-BuildRequires:  yast2-ruby-bindings >= 3.1.26
+# yast/rspec/helpers.rb
+BuildRequires:  yast2-ruby-bindings >= 4.4.7
 # Yast2::CommandLine readonly parameter
 BuildRequires:  yast2 >= 4.2.57
 # systemd-mini does not add the xkb generated map which is needed by 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,10 +45,5 @@ if ENV["COVERAGE"]
   end
 end
 
-# stub module to prevent its Import
-# Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name)
-  Yast.const_set name.to_sym, Class.new { def self.fake_method; end }
-end
-
-stub_module("AutoInstall")
+# stub classes from other modules to avoid build dependencies
+Yast::RSpec::Helpers.define_yast_module("AutoInstall")


### PR DESCRIPTION
- Use the new YaST RSpec helper everywhere
- Additionally fixed changing the current language during test run which might result in failure like
```
         expected: (/selected language cannot be used/)
              got: ("Zvolený jazyk nelze používat ...
```
when the system has default Czech locale and the YaST translations are installed.
- Also fixed test failure in Tumbleweed where it reports `UTF-8` as the default encoding

## TODO

- [x] Inspect the failing Tumbleweed unit test