### PR TITLE
Add explicit glibc-locale dependency

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 28 07:23:35 UTC 2022 - Dirk Müller <dmueller@suse.com>
+
+- add glibc-locale dependency for testsuite
+- 4.4.9
+
+-------------------------------------------------------------------
 Wed Jan 19 09:27:28 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - Switch console keyboard layouts to match the X11 ones

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only
@@ -29,6 +29,7 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-perl-bindings
 # For tests
+BuildRequires:  glibc-locale
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # Fix to bnc#891053 (proper reading of ".target.yast2" on chroots)


### PR DESCRIPTION
The testsuite is using non-base locales so we need the full glibc-locale to pass it.