### PR TITLE
Fixed passing multiple arguments to "localectl set-locale" (bsc#1177863)

### DIFF
--- a/language/src/modules/Language.rb
+++ b/language/src/modules/Language.rb
@@ -1445,7 +1445,7 @@ module Yast
       else
         prepare_locale_settings(locale)
 
-        ["/usr/bin/localectl", "set-locale", localectl_args]
+        ["/usr/bin/localectl", "set-locale", *localectl_args]
       end
     end
 
@@ -1497,9 +1497,9 @@ module Yast
 
     # Returns the locale settings as args for localectl
     #
-    # @return [String] a comma separated locale settings string; i.e, LANG=zh_HK,LC_MESAGES=zh_TW
+    # @return [Array<String>] a list of locale settings; e.g. ["LANG=zh_HK.UTF-8", "LC_MESAGES=zh_TW"]
     def localectl_args
-      @localed_conf.map { |k, v| "#{k}=#{v}" }.join(",")
+      @localed_conf.map { |k, v| "#{k}=#{v}" }
     end
 
 

--- a/language/test/Language_test.rb
+++ b/language/test/Language_test.rb
@@ -205,6 +205,17 @@ describe "Yast::Language" do
 
         subject.Save
       end
+
+      it "passes the localectl settings as separate arguments" do
+        expect(Yast::Execute).to receive(:locally!) do |args|
+            expect(args[0]).to match(/localectl/)
+            expect(args[1]).to eq("set-locale")
+            # the order does not matter
+            expect(args[2..3].sort).to eq(["LANG=zh_HK.UTF-8", "LC_MESSAGES=zh_TW"])
+          end
+
+        subject.Save
+      end
     end
 
     context "when LC_MESSAGES is zh_TW" do

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 31 14:49:03 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed passing multiple arguments to "localectl set-locale"
+  (bsc#1177863)
+- 4.4.11
+
+-------------------------------------------------------------------
 Mon Jan 31 13:48:31 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Unify YaST module mocking in unit tests (related to bsc#1194784)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.10
+Version:        4.4.11
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1177863
- The settings should be passed as separate command arguments (not joined with comma separator into a single parameter)
- 4.4.11