### PR TITLE
Fixed French (Canada) Keyboard Layout

### DIFF
--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -101,7 +101,7 @@ class Keyboards
       },
       { "description" => _("French (Canada)"),
         "alias" => "french-ca",
-        "code" => "ca-fr-legacy", # TO DO: Or just ca? Check!
+        "code" => "ca", # Not ca-fr-legacy (bsc#1196891)
         "legacy_code" => "cf"
       },
       { "description" => _("Canadian (Multilingual)"),

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 14 12:03:14 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed French (Canada) keyboard layout (bsc#1196891):
+  Use "ca", not "ca-fr-legacy"
+- 4.4.12
+
+-------------------------------------------------------------------
 Mon Jan 31 14:49:03 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed passing multiple arguments to "localectl set-locale"

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1196891

## Trello

https://trello.com/c/GFtc5ngl


## Problem

Wrong keyboard layout for French (Canada).
Not to confuse with Canada (multilingual)!


## Fix

Use "ca", not "ca-fr-legacy".


## Test

Compared key by key against the French (Canada) keyboard layout in a Leap 15.3.
See also bug.