### PR TITLE
Language container

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 17 14:39:10 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt language module to run properly in chroot (bsc#1199840)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Language module does not work when run in container. It is caused by limitation that is needed only in insts-sys.


## Solution

Fix to respect chrooting outside of initial stage.


## Testing

- *adapted unit test*
- *Tested manually*

