### PR TITLE
switch to 'multix' variant for Candian CSA layout

### DIFF
--- a/dropping_kbd_legacy.md
+++ b/dropping_kbd_legacy.md
@@ -17,7 +17,7 @@ legacy ones to the ones generated from xkb.
 | be-latin1            | be                   |               |                         |
 | br-abnt2             | br                   | br-nativo     |                         |
 | cf                   | ca-fr-legacy         |               |                         |
-| cn-latin1            | ca-multi             |               |                         |
+| cn-latin1            | ca-multix            |               |                         |
 | croat                | hr                   |               |                         |
 | cz-lat2-us           | cz-qwerty            |               |                         |
 | cz-us-qwertz         | cz                   |               |                         |

--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -106,7 +106,7 @@ class Keyboards
       },
       { "description" => _("Canadian (Multilingual)"),
         "alias" => "cn-latin1",
-        "code" => "ca-multi",
+        "code" => "ca-multix",
         "legacy_code" => "cn-latin1",
         "suggested_for_lang" => ["fr_CA"]
       },

--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -104,7 +104,11 @@ class Keyboards
         "code" => "ca", # Not ca-fr-legacy (bsc#1196891)
         "legacy_code" => "cf"
       },
-      { "description" => _("Canadian (Multilingual)"),
+      {
+        # CSA should probably not be translated;
+        # it stands for Canadian Standards Association
+        # https://en.wikipedia.org/wiki/CSA_keyboard
+        "description" => _("Canadian (CSA)"),
         "alias" => "cn-latin1",
         "code" => "ca-multix",
         "legacy_code" => "cn-latin1",

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 21 07:22:31 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Use Canadian (CSA) instead of Canadian (Multilingual) keyboard
+  layout, adapting to xkeyboard-config-2.37 (bsc#1204573)
+- 4.5.2
+
+-------------------------------------------------------------------
 Fri Jun 17 14:39:10 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt language module to run properly in chroot (bsc#1199840)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
Old 'multi' variant for 'ca' keyboard layout has been deleted upstream with xkeyboard-config 2.37, but newer and less complex 'multix' stays. So switch to the latter.
https://github.com/freedesktop/xkeyboard-config/commit/d46d0f40afb8cb7842959bdd15dfccbc9c041493
