### PR TITLE
Update Language Cache when Selecting new Language [master]

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Nov 24 12:13:15 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Update language cache when selecting new language to ensure that
+  always the correct language translations are used in the license
+  translations selection combo box on the next wizard page
+  (bsc#1204845, bsc#1193009)
+- 4.5.3
+
+-------------------------------------------------------------------
 Fri Oct 21 07:22:31 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - Use Canadian (CSA) instead of Canadian (Multilingual) keyboard

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Target Branch

This is the merge to _master_. The original PR for SLE-15-SP4 is PR https://github.com/yast/yast-country/pull/300.

## Bugzilla

- https://bugzilla.suse.com/show_bug.cgi?id=1204845
- https://bugzilla.suse.com/show_bug.cgi?id=1193009


## Trello

- https://trello.com/c/anbvTsur/
- https://trello.com/c/oVIP4Qln/


## Problem

After selecting an installation language on the "Welcome" page (language / keyboard selection), on the next page ("License"), the "License translations" combo box still has untranslated texts. When going back to the first page and selecting a different language, the combo box on the "License" page is always one language behind: It always has the old language in which the translation languages are displayed in the combo box.

Selecting languages

- German
- Italian
- Czech

and always going back to the first (language / keyboard) page results in this:

![lang-de-it-cz](https://user-images.githubusercontent.com/11538225/203606423-3ee68c23-34d5-42bd-82be-7302999e4797.png)

Most of the widgets are correctly translated to Czech, but the "License translations" combo box still has its content in the _previous_ language, in this case Italian.


## Cause

Too aggressive caching and not updating: The `Language.rb` module has a map containing data from `/usr/share/YaST/data/languages/*` for each language:

```
{
    textdomain "languages_db";

    return
    $[
	// 1. information for language selection:
	// Format is
	// <LANG-Code> : [
	//	<Language-to-display-UTF8-coded>,
	//	<Language-to-display-ASCII-coded-if-needed>,
	//	<LANG modifier used when UTF-8 enconding is selected>
	//	<LANG modifier used when no UTF-8 enconding is selected>
	//	<translated Language-to-display-UTF8-coded> ]
	//
	"cs_CZ"	: [
		    "Čeština",
		    "Cestina",
		    ".UTF-8",
		    "",
		    // language name
		    _("Czech")
	],
	// 2. what time zone propose for this language
	"timezone"	: "Europe/Prague",
	// 3. which keyboard layout propose for this language
	"keyboard"	: "czech",
    ];
}
```

Those files are all read and put into a map where the content is cached. Each file is sent through `Builtins.eval()` to make sure the translation function is executed: `_("Czech")` becomes `Tschechisch` if the current UI language is German, `Čeština` if it's Czech, `Ceco` if it's Italian.

Of course, when the language is changed, that field needs to be retranslated, so the map needs to be rebuilt so the `_(...)` translation method is called again, this time with the new UI language.


## Fix

Re-read the files if the language changed (when the changes are applied).

This is not the most elegant solution; the first idea was to add a `drop_cache` method and reinitialize the internal `@languages_map` variable with an empty map, but unfortunately that code is really old, many methods are exported, and they don't _all_ ensure to initialize the variable (re-read the files) before accessing it.

Doing such an intrusive change would result in a much larger patch and require much more testing. The current changes always leave the variable with data that can be used; in many cases the 4th field that contains the translated name isn't needed anyway (thus the bug remained undetected for so many years).

Caveat: The current code may read those small description files once too often if the user goes back (and only then) to the language / keyboard selection page. Changing that to be 100% correct and avoid superfluous reading of the files would need much bigger changes (which might increase the risk of introducing new bugs, of course).


## Test

Manually tested with an ssh installation and copying / bind-mounting that one file to the inst-sys.


## Related PR

Original PR for SLE-15-SP4: https://github.com/yast/yast-country/pull/300
