### PR TITLE
Add Colemak keyboard layout

### DIFF
--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -253,6 +253,11 @@ class Keyboards
         "code" => "tr",
         "legacy_code" => "trq"
       },
+      { "description" => _("Colemak"),
+        "alias" => "colemak",
+        "code" => "us-colemak",
+        "legacy_code" => "colemak"
+      },
       { "description" => _("Croatian"),
         "alias" => "croatian",
         "code" => "hr",


### PR DESCRIPTION
## Problem

Can not select colemak keyboard layout in yast2, even if it is supported by the system.

## Solution

Add colemak keyboard layout to keyboards list

## Testing

- *Tested manually*