### PR TITLE
Stop using File.exists? which no longer works in Ruby 3.2 (bsc#1206419)

### DIFF
--- a/language/src/lib/y2country/language_dbus.rb
+++ b/language/src/lib/y2country/language_dbus.rb
@@ -34,7 +34,7 @@ module Y2Country
     # @return [Hash] locale variables
     def read_locale_conf
       # dbus not available
-      return nil unless File.exists?("/var/run/dbus/system_bus_socket")
+      return nil unless File.exist?("/var/run/dbus/system_bus_socket")
 
       begin
         require "dbus"

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 10 08:53:15 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using File.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.5.4
+
+-------------------------------------------------------------------
 Thu Nov 24 12:13:15 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Update language cache when selecting new language to ensure that

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Ruby 3.2 removed `File.exists?` which has been long deprecated in favor of `File.exist?`

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419
- build monitor: https://build.opensuse.org/project/monitor/openSUSE:Factory:Staging:H?arch_x86_64=1&defaults=0&failed=1&repo_standard=1

## Solution

The solution is a one-character diff.

## Testing

It fails during unit testing already, good.



## Screenshots

N/A
