### PR TITLE
Fix build with Ruby 3.2

### DIFF
--- a/language/src/lib/y2country/language_dbus.rb
+++ b/language/src/lib/y2country/language_dbus.rb
@@ -34,7 +34,7 @@ module Y2Country
     # @return [Hash] locale variables
     def read_locale_conf
       # dbus not available
-      return nil unless File.exists?("/var/run/dbus/system_bus_socket")
+      return nil unless File.exist?("/var/run/dbus/system_bus_socket")
 
       begin
         require "dbus"

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 10 09:42:21 UTC 2023 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Fix build with Ruby 3.2: File.exists has been deprecated since
+  Ruby 2.1.0 (boo#1206419)
+- 4.5.2
+
+-------------------------------------------------------------------
 Fri Jun 17 14:39:10 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt language module to run properly in chroot (bsc#1199840)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
File.exists has been deprecated since Ruby 2.1



## Problem

Code fails to build with Ruby 3.2 due to usage of deprecated File.exists

- https://bugzilla.opensuse.org/show_bug.cgi?id=1206419


## Solution

Use File.exist, which was introduced in Ruby 2.1


