### PR TITLE
Read local timezone database

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 11 12:13:52 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Always read local timezone database (bsc#1207000).
+- 4.5.5
+
+-------------------------------------------------------------------
 Tue Jan 10 08:53:15 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Stop using File.exists? which no longer works in Ruby 3.2

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -223,7 +223,7 @@ module Yast
     def get_zonemap
       if Builtins.size(@zonemap) == 0
         zmap = Convert.convert(
-          Builtins.eval(SCR.Read(path(".target.yast2"), "timezone_raw.ycp")),
+          Builtins.eval(WFM.Read(path(".local.yast2"), "timezone_raw.ycp")),
           :from => "any",
           :to   => "list <map <string, any>>"
         )


### PR DESCRIPTION
## Problem

Regions and time zones are empty when running "Date and Time" client from a YaST container in ALP.

## Solution

The list of regions is empty because [the database is being read from the host system](https://github.com/yast/yast-country/blob/master/timezone/src/modules/Timezone.rb#L226) (ALP), but  the database is in the container file system. @jreidinger suggested to use WFM instead of SCR to read the database from the local file system (i.e., the container). Doing that, the UI is now correctly populated.

Note: there is still an issue when executing `timedatectl` in host for saving the changes. This will be addressed in a separate bug because is a more generic issue related to SELinux and D-Bus.

## Testing

* Tested manually in running system, installer and YaST container.
