### PR TITLE
Drop mkinitrd

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 28 20:10:19 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Replace call to mkinitrd with dracut (bsc#1203019)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -467,7 +467,8 @@ module Yast
       Builtins.y2milestone("calling mkinitrd...")
       SCR.Execute(
         path(".target.bash"),
-        "/sbin/mkinitrd >> /var/log/YaST2/y2logmkinitrd 2>> /var/log/YaST2/y2logmkinitrd"
+        # force and regenerate all is needed to ensure that change is applied to all kernel versions
+        "/usr/bin/dracut --force --regenerate-all >> /var/log/YaST2/y2logmkinitrd 2>> /var/log/YaST2/y2logmkinitrd"
       )
       Builtins.y2milestone("... done")
       true


### PR DESCRIPTION
## Problem

mkinitrd wrapper will be removed from ALP and probably also from TW.

- https://bugzilla.suse.com/show_bug.cgi?id=1203019
- https://trello.com/c/6NouwiGv/3144-blockerostumbleweed-1203019-yast2-replace-mkinitrd-wrapper-with-native-dracut

## Solution

Replace call to mkinitrd with dracut


## Testing

- *Tested manually* ( note to regenerate initrd it needs to switch between local and UTC hardware time...and yes, it does not stuck, it just wait till initrds are regenerated, so in some cases it can take some time )


