### PR TITLE
Cleanup: use "ru" keymap for Russian, not "ruwin_alt-UTF-8"   (bsc#1194609)

### DIFF
--- a/dropping_kbd_legacy.md
+++ b/dropping_kbd_legacy.md
@@ -67,7 +67,7 @@ once, so removing kbd-legacy would break these languages als in X11.
 | Legacy keyboard map  | Selected replacement | Other options | Note           |
 | -------------------- | -------------------- | ------------- | ---------      |
 | gr                   | ?                    |               | Greek          |
-| ruwin_alt-UTF-8      | ?                    |               | Russian        |
+| ru                   | ?                    |               | Russian        |
 | tj_alt-UTF8          | ?                    |               | Tajik          |
 | ua-utf               | ?                    |               | Ukrainian      |
 

--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -226,7 +226,7 @@ class Keyboards
       },
       { "description" => _("Russian"),
         "alias" => "russian",
-        "code" => "ruwin_alt-UTF-8", # not_in_xkb
+        "code" => "ru", # not_in_xkb
         "suggested_for_lang" => ["ru", "ru_RU.KOI8-R"]
       },
       { "description" => _("Serbian"),

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 20 14:10:19 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Cleanup: use "ru" keymap for Russian, not "ruwin_alt-UTF-8"
+  (bsc#1194609)
+- 4.6.2
+
+-------------------------------------------------------------------
 Tue Mar 28 20:10:19 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Replace call to mkinitrd with dracut (bsc#1203019)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

The SUSE systemd maintainer wants to upstream a patch to `kbd-model-map`

- https://build.opensuse.org/package/view_file/Base:System/systemd/kbd-model-map.legacy?expand=1
- related: https://bugzilla.suse.com/show_bug.cgi?id=1194609

## Solution

Cleanup: use "ru" keymap for Russian, not "ruwin_alt-UTF-8"

ruwin_alt-UTF-8 was introduced in 2008 in response to https://bugzilla.suse.com/show_bug.cgi?id=432862 because the previous keymap did not use Unicode.

"ru" does use Unicode, and it has a dual latin-cyrillic layout (AltGr for single characters, Ctrl-Shift for layout switching)

In /usr/share/systemd/kbd-model-map the Russian keymap is a kbd-model-map.legacy SUSE patch over upstream, and as Franck Bui was reviewing this patch for upstreaming, we found that an entry for Russian is still needed, but a default "ru" keymap has a better chance than a specific one.

## Testing

- we already have a "unit" test checking that the YaST layout is is present in `/usr/share/systemd/kbd-model-map`

## Screenshots

No

