### PR TITLE
Arabic keyboard renamed to 'ara' in kbd.rpm (bsc#1210702)

### DIFF
--- a/dropping_kbd_legacy.md
+++ b/dropping_kbd_legacy.md
@@ -76,7 +76,7 @@ once, so removing kbd-legacy would break these languages als in X11.
 Some languages have never had a native console layout. Their console keymaps
 are simply a symlink to the `us` keymap:
 
-- arabic
+- ara
 - ir (Iran, Persian/Farsi)
 - khmer
 

--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -304,7 +304,7 @@ class Keyboards
       },
       { "description" => _("Arabic"),
         "alias" => "arabic",
-        "code" => "arabic" # us_symlink
+        "code" => "ara" # us_symlink
       },
       { "description" => _("Tajik"),
         "alias" => "tajik",

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 28 08:37:02 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Arabic keyboard renamed to 'ara' in kbd.rpm (bsc#1210702)
+- 4.6.3
+
+-------------------------------------------------------------------
 Thu Apr 20 14:10:19 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Cleanup: use "ru" keymap for Russian, not "ruwin_alt-UTF-8"

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- https://bugzilla.opensuse.org/show_bug.cgi?id=1210702 "Update keyboard layouts 'korean' and 'arabic'"
- https://build.opensuse.org/request/show/1080924 "Submit package home:fbui:branches:[Base:System](https://build.opensuse.org/project/show/Base:System) / [kbd](https://build.opensuse.org/package/show/Base:System/kbd) to package Base:System / kbd"

Cleanup of the SUSE patches in kbd.rpm:

> - 'arabic'
>
> The name is SUSE specific and doesn't match the corresponding x11 layout
> 'ara'. On SUSE, 'arabic' is just an alias to 'us' currently and
> therefore not provided by kbd itself but chances are that the official
> name will be 'ara' (especially if the x11 layout is converted). 'ara' is
> also the name used by Fedora (although for Fedora it's an alias to
> 'fa').
>
> For these reasons it's probably better to rename 'arabic' to 'ara'.

## Solution

Rename also in YaST

## Testing

Existing test fails for Factory and should succeed in Staging with the new kbd.rpm

## Screenshots

No