### PR TITLE
Use localectl instead of reading kbd-model-map (bsc#1211104)

### DIFF
--- a/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
+++ b/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
@@ -36,6 +36,7 @@ module Y2Keyboard
       def initialize
         textdomain "country"
         @keyboard_layouts = KeyboardLayout.all
+        @keyboard_layouts.sort! { |a, b| Yast.strcoll(a.description, b.description) }
         @previous_selected_layout = KeyboardLayout.current_layout
       end
 

--- a/keyboard/test/keyboards_spec.rb
+++ b/keyboard/test/keyboards_spec.rb
@@ -17,16 +17,6 @@ describe "Keyboards" do
         expect(ret.first["suggested_for_lang"].class == Array).to eq(true)
       end
     end
-
-    it "returns a list with all valid models from systemd" do
-      # read valid codes from systemd as xkbctrl read it from there
-      valid_codes = File.readlines("/usr/share/systemd/kbd-model-map")
-      valid_codes.map! { |l| l.strip.sub(/^(\S+)\s+.*$/, "\\1") }
-      Keyboards.all_keyboards.each do |kb_map|
-        code = kb_map["code"]
-        expect(valid_codes).to include(code)
-      end
-    end
   end
 
   describe ".suggested_keyboard" do

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 10 07:56:45 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Use localectl instead of reading kbd-model-map (bsc#1211104)
+- Sort the selection box of keyboard layouts alphabetically
+- 4.6.3
+
+-------------------------------------------------------------------
 Thu Apr 20 14:10:19 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Cleanup: use "ru" keymap for Russian, not "ruwin_alt-UTF-8"

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -2,6 +2,7 @@
 Wed May 10 07:56:45 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Use localectl instead of reading kbd-model-map (bsc#1211104)
+  - Move the related test to t/*.t for openQA use
 - Sort the selection box of keyboard layouts alphabetically
 - 4.6.3
 

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/t/README.md
+++ b/t/README.md
@@ -1,0 +1,22 @@
+# Integration tests of the Command Line Interface (CLI)
+
+The idea is to have in each YaST package a standardized way to run
+integration tests of the CLI features.
+
+Then we should be able to write an adapter for openQA or whatever CI
+system to run such tests.
+
+## Running
+
+> **Warning**, they will reconfigure your system (actually the current ones
+  try to clean up after themselves, but they are not guaranteed to stay this
+  way), so use them in a scratch VM.
+
+```sh
+# run in top level directory as prove searching for 't' directory
+prove --verbose
+```
+
+`prove` is a runner for the [Test Anything Protocol](http://testanything.org/),
+which has a stdio interface and thus is well suited for command line tests.
+The program is conveniently part of a base openSUSE system, in perl5.rpm.

--- a/t/keyboard-layouts.t
+++ b/t/keyboard-layouts.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+require_relative "tap_helper"
+
+tap = TAP.new
+
+tap.test "Keyboards.all_keyboards members only includes items known to localectl" do
+  require "yast"
+  require "y2keyboard/keyboards"
+
+  cmd = "localectl list-keymaps"
+  localectl_keymaps = `#{cmd}`.split("\n")
+  raise "Could not get the list of keymaps from localectl" if localectl_keymaps.empty?
+
+  Keyboards.all_keyboards.each do |kb_map|
+    code = kb_map["code"]
+    next if localectl_keymaps.include?(code)
+
+    raise "YaST keyboard #{kb_map.inspect} not found in '#{cmd}'"
+  end
+end
+
+tap.run

--- a/t/tap_helper.rb
+++ b/t/tap_helper.rb
@@ -1,0 +1,32 @@
+# A quick and dirty [TAP][] runner.
+#
+# [TAP]: http://testanything.org/
+class TAP
+  def initialize
+    @tests = []
+  end
+
+  # Declare a test to be run by {#run}. A failing test raises.
+  def test(description, &body)
+    @tests << [description, body]
+  end
+
+  def run_one(i, description, &body)
+    puts
+    puts "# Beginning #{i} #{description}"
+    body.call
+    puts "ok #{i} #{description}"
+  rescue => e
+    puts "# Exception: #{e}"
+    puts "not ok #{i} #{description}"
+  end
+
+  def run
+    # test plan
+    puts "1..#{@tests.size}"
+    @tests.each_with_index do |item, i|
+      description, body = item
+      run_one(i + 1, description, &body)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

- [bsc#1211104](https://bugzilla.suse.com/show_bug.cgi?id=1211104)

> ### yast-country: please stop parsing /usr/share/systemd/kbd-model-map in the unit tests

>  Basically systemd doesn't need to rely on /usr/share/systemd/kbd-model-map.xkb-generated to convert generated keymaps (those located in /usr/share/kbd/keymaps/xkb/) into x11 layouts, this is done automatically.
> 
> Hence /usr/share/systemd/kbd-model-map has been drastically shrunk and all entries that were previously taken from kbd-model-map.xkb-generated were dropped.
> 
> But it chagrins one of the yast-country unit tests
> 

## Solution

- at run time, call `localectl` instead
- remove the build time test
    - to be replaced by an openQA integration test


## Testing

- *Tested manually*
- and realized the UI does not sort the selection box! And fixed that too
- [ ] test building in the staging project with the new systemd, before and after

## Screenshots

Sorted now, respecting the locale

![yast-country-sorted-keyboards](https://github.com/yast/yast-country/assets/102056/9f0546a9-a6bc-4efa-b952-78b6494016db)


