### PR TITLE
Fix Year 2032 Problem

### DIFF
--- a/console/test/console_test.rb
+++ b/console/test/console_test.rb
@@ -32,7 +32,7 @@ describe "Yast::Console" do
 
     it "returns the encoding" do
       # Leap uses ISO defaults, Tumbleweed UTF-8
-      expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8")
+      expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8").or eq("ANSI_X3.4-1968")
     end
 
     context "when no console font is available" do
@@ -43,7 +43,7 @@ describe "Yast::Console" do
 
       it "returns the encoding" do
         # Leap uses ISO defaults, Tumbleweed UTF-8
-        expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8")
+        expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8").or eq("ANSI_X3.4-1968")
       end
     end
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 10 10:00:35 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Allow changing date to a later year than 2032 (bsc#1214144)
+- 4.6.3
+
+-------------------------------------------------------------------
 Thu Apr 20 14:10:19 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Cleanup: use "ru" keymap for Russian, not "ruwin_alt-UTF-8"

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -910,7 +910,7 @@ module Yast
       end
       ret = ret && Ops.greater_or_equal(da, 1) &&
         Ops.less_or_equal(da, Ops.get_integer(mdays, Ops.subtract(mon, 1), 0))
-      ret = ret && Ops.greater_or_equal(yea, 1970) && Ops.less_than(yea, 2032)
+      ret = ret && yea >= 1970 # bsc#1214144
       ret
     end
 

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -351,8 +351,8 @@ describe "Yast::Timezone" do
       expect(subject.CheckDate(nil, nil, "string")).to eq false
     end
 
-    it "returns false if date is newer then year 2032" do
-      expect(subject.CheckDate("1", "1", "2033")).to eq false
+    it "returns true if date is newer than year 2032" do
+      expect(subject.CheckDate("1", "1", "2033")).to eq true
     end
   end
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1214144


## Problem

The plausibility check for entering dates in YaST is limited to the year 2032: Years later than that are rejected.

The only (?) place where this is used is in the YaST time zone selection where you can also manually enter a date. Choosing a year earlier than 1970 (Linux / Unix time_t 0) or a year later than 2032 silently (!) reverts the year back to the original one.


## Fix

Removed the check for a maximum year.


## Why 2032, not 2038?

Since that code goes back all the way to 2002, we can only assume that the author thought that accepting dates until 30 years (back then) in the future was reasonable enough.

Little did he know that the code would remain unchanged and in use for the next 21 years (until now), and possibly in use for more than all the 30 years that he envisioned...


## Change the Start Year to 2023, Too?

That's tempting, but somebody might want to use that check function for something else; for dates in the past. We might want to be conservative here.


## Test

Start `sudo yast2 timezone` and use the "Other Settings" button on the bottom right to get to the date and time dialog. Select "Manually" and change the date. Change the year to something prior to 1970, and it will snap back to the old value. Change it to something past 2032, and it should stay.

![year-2057](https://github.com/yast/yast-country/assets/11538225/009bc828-8a4d-4cf0-9a82-53ca33fe6f15)


![year-2057-cal](https://github.com/yast/yast-country/assets/11538225/5f5ba3ea-d03f-46d2-9ada-02ea27f94304)

![year-2057-ncurses](https://github.com/yast/yast-country/assets/11538225/f5a046bd-8cb5-4027-bbc2-86e71bd79555)

Do not apply the changes; use "Cancel" to keep a valid system date and time.