### PR TITLE
Backport sp6

### DIFF
--- a/console/test/console_test.rb
+++ b/console/test/console_test.rb
@@ -32,7 +32,7 @@ describe "Yast::Console" do
 
     it "returns the encoding" do
       # Leap uses ISO defaults, Tumbleweed UTF-8
-      expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8")
+      expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8").or eq("ANSI_X3.4-1968")
     end
 
     context "when no console font is available" do
@@ -43,7 +43,7 @@ describe "Yast::Console" do
 
       it "returns the encoding" do
         # Leap uses ISO defaults, Tumbleweed UTF-8
-        expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8")
+        expect(Yast::Console.SelectFont(language)).to eq("ISO-8859-1").or eq("UTF-8").or eq("ANSI_X3.4-1968")
       end
     end
 

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep  6 15:08:10 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Backport:
+-- Allow changing date to a later year than 2032 (bsc#1214144)
+-- Replace call to mkinitrd with dracut (bsc#1203019)
+- 4.6.4
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.0
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -467,7 +467,8 @@ module Yast
       Builtins.y2milestone("calling mkinitrd...")
       SCR.Execute(
         path(".target.bash"),
-        "/sbin/mkinitrd >> /var/log/YaST2/y2logmkinitrd 2>> /var/log/YaST2/y2logmkinitrd"
+        # force and regenerate all is needed to ensure that change is applied to all kernel versions
+        "/usr/bin/dracut --force --regenerate-all >> /var/log/YaST2/y2logmkinitrd 2>> /var/log/YaST2/y2logmkinitrd"
       )
       Builtins.y2milestone("... done")
       true

--- a/timezone/src/modules/Timezone.rb
+++ b/timezone/src/modules/Timezone.rb
@@ -910,7 +910,7 @@ module Yast
       end
       ret = ret && Ops.greater_or_equal(da, 1) &&
         Ops.less_or_equal(da, Ops.get_integer(mdays, Ops.subtract(mon, 1), 0))
-      ret = ret && Ops.greater_or_equal(yea, 1970) && Ops.less_than(yea, 2032)
+      ret = ret && yea >= 1970 # bsc#1214144
       ret
     end
 

--- a/timezone/test/Timezone_test.rb
+++ b/timezone/test/Timezone_test.rb
@@ -351,8 +351,8 @@ describe "Yast::Timezone" do
       expect(subject.CheckDate(nil, nil, "string")).to eq false
     end
 
-    it "returns false if date is newer then year 2032" do
-      expect(subject.CheckDate("1", "1", "2033")).to eq false
+    it "returns true if date is newer than year 2032" do
+      expect(subject.CheckDate("1", "1", "2033")).to eq true
     end
   end
 


### PR DESCRIPTION
## Problem

SP6 branch is based on SP5 so evaluate changes in master and if version differs bump it to avoid version collision.


## Solution

Backport fixes in https://github.com/yast/yast-country/pull/311 and https://github.com/yast/yast-country/pull/306 as it makes sense also for SP6. On other hand https://github.com/yast/yast-country/pull/307 affects only TW.