### PR TITLE
use also kbd-model-map.xkb-generated (bsc#1211104)

### DIFF
--- a/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
+++ b/keyboard/src/lib/y2keyboard/dialogs/layout_selector.rb
@@ -36,6 +36,7 @@ module Y2Keyboard
       def initialize
         textdomain "country"
         @keyboard_layouts = KeyboardLayout.all
+        @keyboard_layouts.sort! { |a, b| Yast.strcoll(a.description, b.description) }
         @previous_selected_layout = KeyboardLayout.current_layout
       end
 

--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -334,6 +334,21 @@ class Keyboards
     ]
   end
 
+  # @return [Array<String>]
+  def self.kbd_model_map_lines
+    filenames = [
+      "/usr/share/systemd/kbd-model-map",
+      # https://bugzilla.suse.com/show_bug.cgi?id=1211104
+      "/usr/share/systemd/kbd-model-map.xkb-generated"
+    ]
+    lines = filenames.map do |fn|
+      File.readlines(fn)
+    rescue Errno::ENOENT
+      []
+    end.flatten
+    lines
+  end
+
   # Some keyboards are present in new openSUSE releases but not in older SLE
   # @see all_keyboards
   def self.optional_keyboards
@@ -345,8 +360,7 @@ class Keyboards
     # The afnor layout was added to xkeyboard-config in 2019-06
     # but SLE15-SP4 only has 2.23 released in 2018
     afnor_test = lambda do
-      kmm = File.read("/usr/share/systemd/kbd-model-map") rescue ""
-      kmm.match?("^fr-afnor")
+      kbd_model_map_lines.any?(/^fr-afnor/)
     end
     afnor = {
       "description" => _("French (AFNOR)"),

--- a/keyboard/src/lib/y2keyboard/keyboards.rb
+++ b/keyboard/src/lib/y2keyboard/keyboards.rb
@@ -342,9 +342,7 @@ class Keyboards
       "/usr/share/systemd/kbd-model-map.xkb-generated"
     ]
     lines = filenames.map do |fn|
-      File.readlines(fn)
-    rescue Errno::ENOENT
-      []
+      File.exist?(fn) ? File.readlines(fn) : []
     end.flatten
     lines
   end

--- a/keyboard/test/keyboards_spec.rb
+++ b/keyboard/test/keyboards_spec.rb
@@ -20,7 +20,7 @@ describe "Keyboards" do
 
     it "returns a list with all valid models from systemd" do
       # read valid codes from systemd as xkbctrl read it from there
-      valid_codes = File.readlines("/usr/share/systemd/kbd-model-map")
+      valid_codes = Keyboards.kbd_model_map_lines
       valid_codes.map! { |l| l.strip.sub(/^(\S+)\s+.*$/, "\\1") }
       Keyboards.all_keyboards.each do |kb_map|
         code = kb_map["code"]

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 10 09:38:22 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- use also kbd-model-map.xkb-generated (bsc#1211104)
+- sort the selection box of keyboard layouts alphabetically
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (#bsc1185510)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

(same problem as in #309)

- [bsc#1211104](https://bugzilla.suse.com/show_bug.cgi?id=1211104)

> ### yast-country: please stop parsing /usr/share/systemd/kbd-model-map in the unit tests

>  Basically systemd doesn't need to rely on /usr/share/systemd/kbd-model-map.xkb-generated to convert generated keymaps (those located in /usr/share/kbd/keymaps/xkb/) into x11 layouts, this is done automatically.
> 
> Hence /usr/share/systemd/kbd-model-map has been drastically shrunk and all entries that were previously taken from kbd-model-map.xkb-generated were dropped.
> 
> But it chagrins one of the yast-country unit tests
> 


## Solution

(The previous attempt to call `localectl` did not work in inst-sys)

- read both `kbd-model-map` and `kbd-model-map.xkb-generated` here
- also in `xkbctrl` in yast2-country: https://github.com/yast/yast-x11/pull/27

## Testing

- Tested manually with `rake run[keyboard]`
- and realized the UI does not sort the selection box! And fixed that too


## Screenshots


Sorted now, respecting the locale

![yast-country-sorted-keyboards](https://github.com/yast/yast-country/assets/102056/9f0546a9-a6bc-4efa-b952-78b6494016db)


