### PR TITLE
BuildRequire kbd

### DIFF
--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 24 11:54:32 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- BuildRequire kbd to fix the build (bsc#1211104)
+- 5.0.2
+
+-------------------------------------------------------------------
 Tue Oct 10 09:38:22 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - use also kbd-model-map.xkb-generated (bsc#1211104)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -41,6 +41,9 @@ BuildRequires:  yast2 >= 4.2.57
 # systemd-mini does not add the xkb generated map which is needed by 
 # the Keyboards.all_keyboards unit/integration test 
 BuildRequires:  systemd
+# for kbd-model-map.xkb-generated
+# systemd systemd requires it but somehow it's missing
+BuildRequires:  kbd
 
 Requires:       timezone
 Requires:       yast2-perl-bindings

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Build fix for #315.

`kbd.rpm` _should_ be present in the build root, as it's Required by `systemd.rpm` which we BuildRequire... but for a reason unknown to me it's not.
It's not beacuse of `systemd-mini.rpm`, my buildroot has the real one.

## Solution

BuildRequire kbd

## Testing

Manual build with https://build.opensuse.org/package/show/Base:System/systemd , passing the unit test
