### PR TITLE
Override ANSI_X3... encoding with UTF-8 (bsc#1216689)

### DIFF
--- a/console/src/modules/Console.rb
+++ b/console/src/modules/Console.rb
@@ -82,8 +82,8 @@ module Yast
 
     # activate a language specific console font
     #
-    # @param	string	language	ISO code of language
-    # @return	[String]	encoding	encoding for console i/o
+    # @param	string	 language  ISO code of language
+    # @return	[String] encoding  encoding for console i/o
 
     def SelectFont(lang)
       fqlanguage = Language.GetLocaleString(lang)
@@ -118,6 +118,12 @@ module Yast
         elsif !Mode.commandline
           UI.SetConsoleFont(@magic, @font, @screenMap, @unicodeMap, @language)
         end
+      end
+
+      if Encoding.console.start_with?("ANSI_")
+        # Don't fall back to ancient ANSI_X3.4-1968 (bsc#1216689)
+        Builtins.y2milestone("Overriding encoding %1 with UTF-8", Encoding.console )
+        Encoding.console = "UTF-8"
       end
 
       Builtins.y2milestone(


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1216689


## Problem

libstorage-ng messages appear in the wrong encoding, so special characters (non-ASCII) are broken (replaced by a `?` each).


## Cause

glibc (?) changed its behavior and now falls back to `ANSI_X3.4-1968` in many cases.


## Fix

_TO DO_


## Test

Manual test in a TW inst-sys with bind-mounting the changed file(s).
