### PR TITLE
Rename Europe/Kiev to Europe/Kyiv to align with timezone 2022b onwards

### DIFF
--- a/language/src/data/languages/language_uk_UA.ycp
+++ b/language/src/data/languages/language_uk_UA.ycp
@@ -36,7 +36,7 @@
 		    _("Ukrainian")
 	],
 	// 2. what time zone propose for this language
-	"timezone"	: "Europe/Kiev",
+	"timezone"	: "Europe/Kyiv",
 	// 3. which keyboard layout propose for this language
 	"keyboard"	: "ukrainian",
     ];

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 20:41:25 UTC 2024 - jjindrak@suse.com
+
+- Rename Europe/Kiev to Europe/Kyiv as per 2022b release of
+  tz code and data by ICANN (bsc#1224387)
+- 4.5.6
+
+-------------------------------------------------------------------
 Wed Jan 11 12:13:52 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Always read local timezone database (bsc#1207000).

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/data/lang2tz.ycp
+++ b/timezone/src/data/lang2tz.ycp
@@ -65,7 +65,7 @@ $[
 
   "ru"			: "Europe/Moscow",
   "ru_RU.KOI8-R"	: "Europe/Moscow",
-  "ru_UA"		: "Europe/Kiev",
+  "ru_UA"		: "Europe/Kyiv",
 
   "sr_YU"		: "Europe/Belgrade",
 

--- a/timezone/src/data/timezone_raw.ycp
+++ b/timezone/src/data/timezone_raw.ycp
@@ -47,7 +47,7 @@ $[
 	// time zone
 	"Europe/Kaliningrad"	: _("Russia (Kaliningrad)"),
 	// time zone
-	"Europe/Kiev"		: _("Ukraine (Kiev)"),
+	"Europe/Kyiv"		: _("Ukraine (Kyiv)"),
 	"Europe/Lisbon" : _("Portugal"),
 	"Europe/Ljubljana" : _("Slovenia"),
 	"Europe/London" : _("United Kingdom"),


### PR DESCRIPTION
## Problem

In August 2022, the release of tz data/code of version 2022b renamed the Europe/Kiev timezone to Europe/Kyiv:

https://mm.icann.org/pipermail/tz-announce/2022-August/000071.html

This PR fixes the occurrences of the timezone name in yast-country.

This change has a caveat: With yast-translations not being updated, the new timezone label will not match any msgid and thus will not be translated. For example, I set my system to Czech localization and executed yast2 timezone, where I saw:

    Turecko
    Ukraine (Kyiv) <-- not translated
    Ukrajina (Simferopol)

I'm planning to open also a PR for yast-translations that changes all msgid from 'Ukraine (Kiev)' to 'Ukraine (Kyiv)' with the msgstr being untouched (the translations are still the same) because the timezone 'Ukraine (Kiev)' no longer exists and that msgid (at least to my knowledge) has no other use.

*    https://bugzilla.suse.com/show_bug.cgi?id=1224387 (L3)
