### PR TITLE
Rename Europe/Kiev to Europe/Kyiv [SLE-15-SP6]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v2
 
+    - name: Install Needed Packages
+      # kbd is needed for runing the unit tests
+      run:  zypper --non-interactive install --no-recommends kbd
+
     # just for easier debugging...
     - name: Inspect Installed Packages
       run: rpm -qa | sort

--- a/language/src/data/languages/language_uk_UA.ycp
+++ b/language/src/data/languages/language_uk_UA.ycp
@@ -36,7 +36,7 @@
 		    _("Ukrainian")
 	],
 	// 2. what time zone propose for this language
-	"timezone"	: "Europe/Kiev",
+	"timezone"	: "Europe/Kyiv",
 	// 3. which keyboard layout propose for this language
 	"keyboard"	: "ukrainian",
     ];

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 20:41:25 UTC 2024 - jjindrak@suse.com
+
+- Rename Europe/Kiev to Europe/Kyiv as per 2022b release of
+  tz code and data by ICANN (bsc#1224387)
+- 4.6.7
+
+-------------------------------------------------------------------
 Tue Oct 24 11:54:32 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - BuildRequire kbd to fix the build (bsc#1211104)

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        4.6.6
+Version:        4.6.7
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only

--- a/timezone/src/data/lang2tz.ycp
+++ b/timezone/src/data/lang2tz.ycp
@@ -65,7 +65,7 @@ $[
 
   "ru"			: "Europe/Moscow",
   "ru_RU.KOI8-R"	: "Europe/Moscow",
-  "ru_UA"		: "Europe/Kiev",
+  "ru_UA"		: "Europe/Kyiv",
 
   "sr_YU"		: "Europe/Belgrade",
 

--- a/timezone/src/data/timezone_raw.ycp
+++ b/timezone/src/data/timezone_raw.ycp
@@ -47,7 +47,7 @@ $[
 	// time zone
 	"Europe/Kaliningrad"	: _("Russia (Kaliningrad)"),
 	// time zone
-	"Europe/Kiev"		: _("Ukraine (Kiev)"),
+	"Europe/Kyiv"		: _("Ukraine (Kyiv)"),
 	"Europe/Lisbon" : _("Portugal"),
 	"Europe/Ljubljana" : _("Slovenia"),
 	"Europe/London" : _("United Kingdom"),


### PR DESCRIPTION
## Target Branch

This is a merge of #324 to SLE-15-SP6, to be merged later to _master_ as well.


## Problem

The _Europe/Kiev_ timezone was renamed to _Europe/Kyiv_. See #324 for details.


## Merging

This will be on hold until our CI is set up to target `SLE-15-SP6:Update`. This will take a few days.