### PR TITLE
Load required "setxkbmap" package on demand (bsc#1243088)

### DIFF
--- a/keyboard/src/lib/y2keyboard/clients/keyboard.rb
+++ b/keyboard/src/lib/y2keyboard/clients/keyboard.rb
@@ -110,14 +110,29 @@ module Yast
       end
     end
 
+    # Make sure that all needed packages are installed
+    #
+    # @return [Boolean]
+    def self.required_packages_installed
+      return true if UI.TextMode
+
+      # setxkbmap is needed in dialogs/layout_selector.rb for changing the X11
+      # keyboard layout on the fly, and for restoring the original one if the
+      # user cancels the dialog (bsc#1243088).
+      Package.InstallAll(["setxkbmap"])
+    end
+
     def self.setup
       Yast.import "Stage"
       Yast.import "Mode"
+      Yast.import "Package"
 
       if Yast::Stage.initial || Yast::Mode.config
         # In installation mode or AY configuration mode
         strategy = Y2Keyboard::Strategies::YastProposalStrategy.new
       else
+        return unless required_packages_installed
+
         # running system --> using systemd
         strategy = Y2Keyboard::Strategies::SystemdStrategy.new
       end

--- a/keyboard/test/clients/keyboard_spec.rb
+++ b/keyboard/test/clients/keyboard_spec.rb
@@ -23,6 +23,7 @@ require "y2keyboard/dialogs/layout_selector"
 require "y2keyboard/strategies/systemd_strategy"
 
 Yast.import "Directory"
+Yast.import "Package"
 
 describe Yast::KeyboardClient do
   describe ".setup" do
@@ -35,6 +36,7 @@ describe Yast::KeyboardClient do
       allow(Y2Keyboard::Strategies::SystemdStrategy).to receive(:new).and_return(systemd_strategy)
       allow(Y2Keyboard::Strategies::YastProposalStrategy).to receive(:new).and_return(yast_proposal_strategy)
       allow(Y2Keyboard::Dialogs::LayoutSelector).to receive(:new).and_return(dialog)
+      allow(Yast::Package).to receive(:InstallAll).with(["setxkbmap"]).and_return(true)
     end
 
     it "load keyboard layouts definitions from data directory" do

--- a/keyboard/test/keyboard_spec.rb
+++ b/keyboard/test/keyboard_spec.rb
@@ -9,6 +9,10 @@ Yast.import "Keyboard"
 describe "Yast::Keyboard" do
   subject { Yast::Keyboard }
 
+  before do
+    allow(File).to receive(:executable?).with("/usr/sbin/xkbctrl").and_return(false)
+  end
+
   describe "#GetKeyboardForLanguage" do
     let (:search_language) {"en_US"}
 

--- a/keyboard/test/layout_selector_spec.rb
+++ b/keyboard/test/layout_selector_spec.rb
@@ -34,6 +34,7 @@ describe Y2Keyboard::Dialogs::LayoutSelector do
     allow(Yast::UI).to receive(:CloseDialog).and_return(true)
     allow(Y2Keyboard::KeyboardLayout).to receive(:current_layout).and_return(english)
     allow(Y2Keyboard::KeyboardLayout).to receive(:all).and_return(layouts)
+    allow(File).to receive(:executable?).with("/usr/sbin/xkbctrl").and_return(false)
   end
 
   describe "#run" do

--- a/package/yast2-country.changes
+++ b/package/yast2-country.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 14 12:47:00 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Load required "setxkbmap" package on demand (bsc#1243088)
+- 5.0.4
+
+-------------------------------------------------------------------
 Thu May 16 20:41:25 UTC 2024 - jjindrak@suse.com
 
 - Rename Europe/Kiev to Europe/Kyiv as per 2022b release of

--- a/package/yast2-country.spec
+++ b/package/yast2-country.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-country
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 Summary:        YaST2 - Country Settings (Language, Keyboard, and Timezone)
 License:        GPL-2.0-only


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1243088


## Problem

The `yast2 keyboard` module uses the external `setxkbmap` command from the _setxkbmap_ package to change the keyboard layout on the fly so the user can test it, but it didn't ensure that package was even installed, so the user got an error.

It was even more confusing because that error also appeared when the user closed the dialog with the `[x]` window manager close button at the top right corner.


## Fix 

Now checking if we are running in graphical mode (in the Qt UI), and if yes, installing the `setxkbmap` package after prompting the user.


## Why the error when the WM_CLOSE button was used?

The keyboard is changed on the fly immediately when clicking in the list of available layouts, and if the user cancels the dialog (with the "Cancel" button or the `[x]` WM_CLOSE button), the previous keyboard layout is restored, which uses the same command.

Otherwise the user would be stuck with whatever keyboard layout was last selected from the list for the duration of the current graphical session.